### PR TITLE
배포 워크플로우 Flyway 실패 진단 강화 및 마이그레이션 문서 보정

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -334,6 +334,39 @@ jobs:
             sudo systemctl restart "${SERVICE_NAME}"
             sudo systemctl is-active --quiet "${SERVICE_NAME}"
 
+            collect_diagnostics() {
+              echo "Collecting service diagnostics..."
+              sudo systemctl status "${SERVICE_NAME}" --no-pager -l || true
+              sudo journalctl -u "${SERVICE_NAME}" -n 300 --no-pager || true
+            }
+
+            print_flyway_recovery_hint_if_needed() {
+              if sudo journalctl -u "${SERVICE_NAME}" -n 300 --no-pager | grep -Eiq "FlywayValidateException|Detected failed migration to version|Migrations have failed validation"; then
+                echo "Detected Flyway validation failure in service logs."
+                cat <<EOF
+Suggested recovery commands on backend host (verify in production DB before executing):
+1) Stop service
+   sudo systemctl stop "${SERVICE_NAME}"
+
+2) Check Flyway history
+   SELECT installed_rank, version, description, success
+   FROM flyway_schema_history
+   WHERE version IN ('7','8','9','10')
+   ORDER BY installed_rank;
+
+3) If version 7 failed and document storage tables are safe to recreate
+   SET FOREIGN_KEY_CHECKS=0;
+   DROP TABLE IF EXISTS document_backup_jobs;
+   DROP TABLE IF EXISTS document_files;
+   SET FOREIGN_KEY_CHECKS=1;
+   DELETE FROM flyway_schema_history WHERE version='7' AND success=0;
+
+4) Start service again
+   sudo systemctl start "${SERVICE_NAME}"
+EOF
+              fi
+            }
+
             for i in {1..12}; do
               if curl -fsS "${HEALTH_URL}"; then
                 echo "Health check succeeded on attempt ${i}"
@@ -347,11 +380,21 @@ jobs:
                 echo "Health check succeeded on attempt ${i} (local liveness fallback)"
                 exit 0
               fi
+
+              if ! sudo systemctl is-active --quiet "${SERVICE_NAME}"; then
+                echo "Service became inactive while waiting for health check (attempt ${i})."
+                collect_diagnostics
+                print_flyway_recovery_hint_if_needed
+                exit 1
+              fi
+
               echo "Health check failed on attempt ${i}, retrying in 5s..."
               sleep 5
             done
 
             echo "Health check failed after retries. Collecting diagnostics..."
-            sudo systemctl status "${SERVICE_NAME}" --no-pager -l || true
-            sudo journalctl -u "${SERVICE_NAME}" -n 200 --no-pager || true
+            collect_diagnostics
+            print_flyway_recovery_hint_if_needed
             exit 1
+
+

--- a/docs/migration/MIGRATION.md
+++ b/docs/migration/MIGRATION.md
@@ -79,17 +79,17 @@
 
 ### 4.3 documents
 
-| 컬럼 | 타입 | 제약 | 설명 |
-|---|---|---|---|
-| `id` | BIGINT | PK, AUTO_INCREMENT | 식별자 |
-| `company_code` | VARCHAR(20) | NULL, FK → companies | 소속 회사 코드 (NULL = 공통 문서) |
-| `title` | VARCHAR(200) | NOT NULL | 문서 제목 |
-| `file_path` | VARCHAR(500) | NOT NULL | 스토리지 오브젝트 경로 |
-| `document_type` | VARCHAR(50) | NOT NULL | 문서 유형 |
-| `department` | VARCHAR(50) | NOT NULL | 부서 |
-| `is_active` | BOOLEAN | NOT NULL, DEFAULT TRUE | 활성 여부 |
-| `created_at` | DATETIME | NOT NULL, DEFAULT NOW | 생성 일시 |
-| `updated_at` | DATETIME | NOT NULL, ON UPDATE NOW | 수정 일시 |
+| 컬럼 | 타입 | 제약 | 설명                                    |
+|---|---|---|---------------------------------------|
+| `id` | BIGINT | PK, AUTO_INCREMENT | 식별자                                   |
+| `company_code` | VARCHAR(20) | NULL, FK → companies | 소속 회사 코드 (NULL = 공통 문서)               |
+| `title` | VARCHAR(200) | NOT NULL | 문서 제목                                 |
+| `file_path` | VARCHAR(500) | NOT NULL | 스토리지 오브젝트 경로                          |
+| `document_type` | VARCHAR(50) | NOT NULL | 문서 유형 (HR, ADMIN, WELFARE, IT, LEGAL) |
+| `department` | VARCHAR(50) | NOT NULL | 부서                                    |
+| `is_active` | BOOLEAN | NOT NULL, DEFAULT TRUE | 활성 여부                                 |
+| `created_at` | DATETIME | NOT NULL, DEFAULT NOW | 생성 일시                                 |
+| `updated_at` | DATETIME | NOT NULL, ON UPDATE NOW | 수정 일시                                 |
 
 - `company_code = NULL`인 문서는 전체 회사 공통 문서로 처리한다.
 - `file_path`는 스토리지 업로드 메타데이터 기반 구조로 유지한다 (SCRUM 스펙의 `form_file_url`에 해당).
@@ -355,3 +355,4 @@ Flyway 마이그레이션 도입 이후 해당 파일의 DDL은 V7, V8로 이관
 
 - [ERD](../erd/erd.md)
 - [API 명세](../API.md)
+


### PR DESCRIPTION
## 변경 내용
- backend 배포 워크플로우에 서비스 진단 함수(`collect_diagnostics`) 추가
- Flyway 검증 실패 로그 감지 함수(`print_flyway_recovery_hint_if_needed`) 추가
- 헬스체크 재시도 중 서비스 비활성화 시 즉시 실패 처리 및 진단/복구 힌트 출력
- 최종 실패 지점에서도 동일 진단/복구 힌트 출력
- `docs/migration/MIGRATION.md`의 `documents.document_type` 설명 라인 보정

## 커밋 범위
- 요청하신 `d48e900` 내용을 main 기준 브랜치에 단일 체리픽으로 반영했습니다.
- main 대비 포함 커밋: 1개 (`b198e31`)

## 검증
- `git log --oneline origin/main..HEAD`
- `git diff -- .github/workflows/backend-deploy.yml`
- `git diff -- docs/migration/MIGRATION.md`