### PR TITLE
ci: 백엔드 배포 전 Flyway 실패 이력 자동 정리 단계 추가

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -150,6 +150,54 @@ jobs:
           target: ${{ secrets.BACKEND_APP_DIR }}
           overwrite: true
 
+      - name: Repair Flyway failed migrations
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          SPRING_DB_URL: ${{ secrets.SPRING_DB_URL }}
+          SPRING_DB_USERNAME: ${{ secrets.SPRING_DB_USERNAME }}
+          SPRING_DB_PASSWORD: ${{ secrets.SPRING_DB_PASSWORD }}
+        with:
+          host: ${{ secrets.BACKEND_SERVER_HOST }}
+          username: ${{ secrets.BACKEND_SERVER_USER }}
+          key: ${{ secrets.BACKEND_SERVER_SSH_KEY }}
+          envs: SPRING_DB_URL,SPRING_DB_USERNAME,SPRING_DB_PASSWORD
+          script: |
+            set -euo pipefail
+
+            # Parse JDBC URL: jdbc:mysql://host:port/dbname?params
+            DB_RAW="${SPRING_DB_URL#jdbc:mysql://}"
+            DB_RAW="${DB_RAW%%\?*}"
+            DB_HOSTPORT="${DB_RAW%%/*}"
+            DB_NAME="${DB_RAW#*/}"
+            DB_HOST="${DB_HOSTPORT%%:*}"
+            DB_PORT="${DB_HOSTPORT##*:}"
+            if [ "${DB_HOST}" = "${DB_PORT}" ] || [ -z "${DB_PORT}" ]; then
+              DB_PORT="3306"
+            fi
+
+            echo "Checking Flyway schema history for failed migrations..."
+            FAILED=$(mysql -h "${DB_HOST}" -P "${DB_PORT}" \
+              -u "${SPRING_DB_USERNAME}" -p"${SPRING_DB_PASSWORD}" \
+              --skip-column-names --silent \
+              "${DB_NAME}" \
+              -e "SELECT COUNT(*) FROM flyway_schema_history WHERE success=0;" 2>/dev/null || echo "0")
+
+            if [ "${FAILED:-0}" -gt 0 ]; then
+              echo "Found ${FAILED} failed migration(s). Running repair..."
+              mysql -h "${DB_HOST}" -P "${DB_PORT}" \
+                -u "${SPRING_DB_USERNAME}" -p"${SPRING_DB_PASSWORD}" \
+                "${DB_NAME}" <<'REPAIR_SQL'
+SET FOREIGN_KEY_CHECKS=0;
+DROP TABLE IF EXISTS document_backup_jobs;
+DROP TABLE IF EXISTS document_files;
+SET FOREIGN_KEY_CHECKS=1;
+DELETE FROM flyway_schema_history WHERE success=0;
+REPAIR_SQL
+              echo "Flyway repair completed. Tables dropped and failed history cleared."
+            else
+              echo "No failed migrations found. Skipping repair."
+            fi
+
       - name: Restart backend
         uses: appleboy/ssh-action@v1.2.0
         env:


### PR DESCRIPTION
## 변경 내용
- `.github/workflows/backend-deploy.yml`에 `Repair Flyway failed migrations` 단계 추가
- 배포 서버에서 `SPRING_DB_URL`을 파싱해 DB 접속 후 `flyway_schema_history`의 `success=0` 이력 존재 여부 확인
- 실패 이력이 있으면 아래 정리 수행 후 배포 재시도
  - `document_backup_jobs` → `document_files` 순서로 `DROP TABLE IF EXISTS`
  - `flyway_schema_history`에서 `success=0` 레코드 삭제
- 실패 이력이 없으면 스킵하여 정상 배포 경로에 영향 없음

## 검증
- `git diff --check .github/workflows/backend-deploy.yml`
- 삽입된 단계의 YAML 들여쓰기/스크립트 블록 확인

## 참고
- `application-prod.yml`의 `spring.flyway.repair-on-migrate`는 Spring Boot 3.5.13 `FlywayProperties`에 항목이 없어 동작 보장이 어려워 이번 PR에는 포함하지 않았습니다.
- 커밋: `f23a6d2`