### PR TITLE
Fix/backend deploy yaml line436

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -179,8 +179,25 @@ jobs:
               exit 1
             fi
             if ! command -v mysql >/dev/null 2>&1; then
-              echo "ERROR: mysql client is required for Flyway repair step."
-              exit 1
+              echo "WARN: mysql client is not installed on backend host."
+              if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+                if command -v apt-get >/dev/null 2>&1; then
+                  echo "Attempting to install mysql client via apt-get..."
+                  sudo apt-get update -y >/dev/null 2>&1 || true
+                  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-client >/dev/null 2>&1 || true
+                  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y default-mysql-client >/dev/null 2>&1 || true
+                elif command -v dnf >/dev/null 2>&1; then
+                  echo "Attempting to install mysql client via dnf..."
+                  sudo dnf install -y mysql >/dev/null 2>&1 || true
+                elif command -v yum >/dev/null 2>&1; then
+                  echo "Attempting to install mysql client via yum..."
+                  sudo yum install -y mysql >/dev/null 2>&1 || true
+                fi
+              fi
+            fi
+            if ! command -v mysql >/dev/null 2>&1; then
+              echo "WARN: mysql client is still unavailable. Skipping Flyway repair step."
+              exit 0
             fi
 
             mysql_scalar() {

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -431,27 +431,25 @@ jobs:
             print_flyway_recovery_hint_if_needed() {
               if sudo journalctl -u "${SERVICE_NAME}" -n 300 --no-pager | grep -Eiq "FlywayValidateException|Detected failed migration to version|Migrations have failed validation"; then
                 echo "Detected Flyway validation failure in service logs."
-                cat <<EOF
-Suggested recovery commands on backend host (verify in production DB before executing):
-1) Stop service
-   sudo systemctl stop "${SERVICE_NAME}"
-
-2) Check Flyway history
-   SELECT installed_rank, version, description, success
-   FROM flyway_schema_history
-   WHERE version IN ('7','8','9','10')
-   ORDER BY installed_rank;
-
-3) If version 7 failed and document storage tables are safe to recreate
-   SET FOREIGN_KEY_CHECKS=0;
-   DROP TABLE IF EXISTS document_backup_jobs;
-   DROP TABLE IF EXISTS document_files;
-   SET FOREIGN_KEY_CHECKS=1;
-   DELETE FROM flyway_schema_history WHERE version='7' AND success=0;
-
-4) Start service again
-   sudo systemctl start "${SERVICE_NAME}"
-EOF
+                echo "Suggested recovery commands on backend host (verify in production DB before executing):"
+                echo "1) Stop service"
+                echo "   sudo systemctl stop \"${SERVICE_NAME}\""
+                echo ""
+                echo "2) Check Flyway history"
+                echo "   SELECT installed_rank, version, description, success"
+                echo "   FROM flyway_schema_history"
+                echo "   WHERE version IN ('7','8','9','10')"
+                echo "   ORDER BY installed_rank;"
+                echo ""
+                echo "3) If version 7 failed and document storage tables are safe to recreate"
+                echo "   SET FOREIGN_KEY_CHECKS=0;"
+                echo "   DROP TABLE IF EXISTS document_backup_jobs;"
+                echo "   DROP TABLE IF EXISTS document_files;"
+                echo "   SET FOREIGN_KEY_CHECKS=1;"
+                echo "   DELETE FROM flyway_schema_history WHERE version='7' AND success=0;"
+                echo ""
+                echo "4) Start service again"
+                echo "   sudo systemctl start \"${SERVICE_NAME}\""
               fi
             }
 


### PR DESCRIPTION
make flyway repair step tolerate missing mysql client

mysql이 없으면 자동 설치를 시도합니다 (apt-get, dnf, yum 순으로 감지).
설치 후에도 mysql이 없으면 배포 전체를 실패시키지 않고, Flyway repair 단계만 경고 후 스킵
“있으면 repair 실행, 없으면 설치 시도, 끝까지 없으면 repair만 건너뛰고 배포는 계속” 동작