### PR TITLE
release/main-auth-chat-ai-redis -> main: chat 안정화, AI timeout, infra 정리, benchmark 추가

### DIFF
--- a/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/chat")
@@ -56,5 +58,11 @@ public class ChatMessageController {
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
         }
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/quick-questions")
+    @ResponseStatus(HttpStatus.OK)
+    public Map<String, List<Map<String, String>>> getQuickQuestions() {
+        return Map.of("quickQuestions", List.of());
     }
 }

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -10,10 +10,14 @@ import com.withbuddy.chat.entity.MessageType;
 import com.withbuddy.chat.entity.SenderType;
 import com.withbuddy.chat.repository.ChatMessageDocumentRepository;
 import com.withbuddy.chat.repository.ChatMessageRepository;
+import com.withbuddy.global.exception.UnauthorizedException;
 import com.withbuddy.global.jwt.JwtService;
 import com.withbuddy.infrastructure.ai.dto.AiAnswerServerRequest;
 import com.withbuddy.infrastructure.ai.dto.AiAnswerServerResponse;
 import com.withbuddy.infrastructure.ai.dto.AiUserContext;
+import com.withbuddy.infrastructure.redis.RedisCacheKeys;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
+import com.withbuddy.infrastructure.redis.RedisCacheTtl;
 import com.withbuddy.storage.entity.Document;
 import com.withbuddy.storage.entity.DocumentFile;
 import com.withbuddy.storage.repository.DocumentFileRepository;
@@ -26,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -39,6 +44,7 @@ public class ChatMessageService {
     private final DocumentFileRepository documentFileRepository;
     private final JwtService jwtService;
     private final AiClient aiClient;
+    private final RedisCacheService redisCacheService;
 
     @Transactional
     public ChatMessageCreateResponse saveUserMessage(String bearerToken, ChatMessageRequest request) {
@@ -56,6 +62,16 @@ public class ChatMessageService {
         );
 
         ChatMessage savedQuestionMessage = chatMessageRepository.save(questionMessage);
+        redisCacheService.put(
+                RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
+                "PENDING",
+                RedisCacheTtl.RAG_STATUS
+        );
+        redisCacheService.put(
+                RedisCacheKeys.conversation(String.valueOf(loginUserId)),
+                savedQuestionMessage.getContent(),
+                RedisCacheTtl.CONVERSATION
+        );
 
         AiUserContext userContext = new AiUserContext(
                 loginUserId,
@@ -69,14 +85,29 @@ public class ChatMessageService {
                 savedQuestionMessage.getContent()
         );
 
-        AiAnswerServerResponse aiResponse = aiClient.requestAnswer(aiRequest);
+        AiAnswerServerResponse aiResponse;
+        try {
+            aiResponse = aiClient.requestAnswer(aiRequest);
+        } catch (RuntimeException ex) {
+            redisCacheService.put(
+                    RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
+                    "TIMEOUT",
+                    RedisCacheTtl.RAG_STATUS
+            );
+            throw ex;
+        }
 
         if (!savedQuestionMessage.getId().equals(aiResponse.getQuestionId())) {
             throw new IllegalStateException("AI 응답의 questionId가 저장된 질문 ID와 일치하지 않습니다.");
         }
+        redisCacheService.put(
+                RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
+                "COMPLETED",
+                RedisCacheTtl.RAG_STATUS
+        );
 
         MessageType answerMessageType = aiResponse.getMessageType();
-        List<Long> answerDocumentIds = extractDocumentIds(aiResponse);
+        List<Long> answerDocumentIds = filterExistingDocumentIds(extractDocumentIds(aiResponse));
 
         ChatMessage answerMessage = new ChatMessage(
                 loginUserId,
@@ -201,6 +232,20 @@ public class ChatMessageService {
                 .toList();
     }
 
+    private List<Long> filterExistingDocumentIds(List<Long> documentIds) {
+        if (documentIds == null || documentIds.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> existingIds = documentRepository.findByIdInAndIsActiveTrue(documentIds).stream()
+                .map(Document::getId)
+                .collect(Collectors.toSet());
+
+        return documentIds.stream()
+                .filter(existingIds::contains)
+                .toList();
+    }
+
     private void saveDocumentMappings(Long chatMessageId, List<Long> documentIds) {
         if (documentIds == null || documentIds.isEmpty()) {
             return;
@@ -218,7 +263,7 @@ public class ChatMessageService {
 
     private String extractToken(String bearerToken) {
         if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("Authorization 헤더 형식이 올바르지 않습니다.");
+            throw new UnauthorizedException("Authorization 헤더 형식이 올바르지 않습니다.");
         }
         return bearerToken.substring(7);
     }

--- a/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AiConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AiConfig.java
@@ -11,11 +11,13 @@ public class AiConfig {
 
     @Bean
     public RestClient aiRestClient(
-            @Value("${ai.server.base-url}") String aiBaseUrl
+            @Value("${ai.server.base-url}") String aiBaseUrl,
+            @Value("${ai.server.connect-timeout-ms:5000}") int connectTimeoutMs,
+            @Value("${ai.server.read-timeout-ms:20000}") int readTimeoutMs
     ) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(5000);
-        requestFactory.setReadTimeout(5000);
+        requestFactory.setConnectTimeout(connectTimeoutMs);
+        requestFactory.setReadTimeout(readTimeoutMs);
 
         return RestClient.builder()
                 .baseUrl(aiBaseUrl)

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/AppRabbitMqProperties.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/AppRabbitMqProperties.java
@@ -5,7 +5,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "app.rabbitmq")
 public record AppRabbitMqProperties(
         String exchange,
+        String dlxExchange,
         String queueReport,
-        String queueDlq
+        String queueNudge,
+        String queueAnalytics,
+        String queueDlq,
+        String queueDlqNudge,
+        String queueDlqAnalytics,
+        Integer nudgeTtlMs
 ) {
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
@@ -3,6 +3,7 @@ package com.withbuddy.infrastructure.mq;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Declarables;
+import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.core.TopicExchange;
@@ -22,36 +23,96 @@ public class RabbitMqConfig {
     }
 
     @Bean
+    public DirectExchange deadLetterExchange(AppRabbitMqProperties properties) {
+        return new DirectExchange(properties.dlxExchange(), true, false);
+    }
+
+    @Bean
     public Queue reportQueue(AppRabbitMqProperties properties) {
         return QueueBuilder.durable(properties.queueReport())
-                .withArgument("x-dead-letter-exchange", properties.exchange())
+                .withArgument("x-dead-letter-exchange", properties.dlxExchange())
                 .withArgument("x-dead-letter-routing-key", properties.queueDlq())
                 .build();
     }
 
     @Bean
-    public Queue deadLetterQueue(AppRabbitMqProperties properties) {
+    public Queue nudgeQueue(AppRabbitMqProperties properties) {
+        return QueueBuilder.durable(properties.queueNudge())
+                .withArgument("x-dead-letter-exchange", properties.dlxExchange())
+                .withArgument("x-dead-letter-routing-key", properties.queueDlqNudge())
+                .withArgument("x-message-ttl", properties.nudgeTtlMs())
+                .build();
+    }
+
+    @Bean
+    public Queue analyticsQueue(AppRabbitMqProperties properties) {
+        return QueueBuilder.durable(properties.queueAnalytics())
+                .withArgument("x-dead-letter-exchange", properties.dlxExchange())
+                .withArgument("x-dead-letter-routing-key", properties.queueDlqAnalytics())
+                .build();
+    }
+
+    @Bean
+    public Queue deadLetterReportQueue(AppRabbitMqProperties properties) {
         return new Queue(properties.queueDlq(), true);
+    }
+
+    @Bean
+    public Queue deadLetterNudgeQueue(AppRabbitMqProperties properties) {
+        return new Queue(properties.queueDlqNudge(), true);
+    }
+
+    @Bean
+    public Queue deadLetterAnalyticsQueue(AppRabbitMqProperties properties) {
+        return new Queue(properties.queueDlqAnalytics(), true);
     }
 
     @Bean
     public Declarables appBindings(
             TopicExchange appExchange,
+            DirectExchange deadLetterExchange,
             Queue reportQueue,
-            Queue deadLetterQueue,
+            Queue nudgeQueue,
+            Queue analyticsQueue,
+            Queue deadLetterReportQueue,
+            Queue deadLetterNudgeQueue,
+            Queue deadLetterAnalyticsQueue,
             AppRabbitMqProperties properties
     ) {
         Binding reportBinding = BindingBuilder
                 .bind(reportQueue)
                 .to(appExchange)
                 .with(properties.queueReport());
-
-        Binding dlqBinding = BindingBuilder
-                .bind(deadLetterQueue)
+        Binding nudgeBinding = BindingBuilder
+                .bind(nudgeQueue)
                 .to(appExchange)
-                .with(properties.queueDlq());
+                .with("nudge.#");
+        Binding analyticsBinding = BindingBuilder
+                .bind(analyticsQueue)
+                .to(appExchange)
+                .with("analytics.#");
 
-        return new Declarables(reportBinding, dlqBinding);
+        Binding reportDlqBinding = BindingBuilder
+                .bind(deadLetterReportQueue)
+                .to(deadLetterExchange)
+                .with(properties.queueDlq());
+        Binding nudgeDlqBinding = BindingBuilder
+                .bind(deadLetterNudgeQueue)
+                .to(deadLetterExchange)
+                .with(properties.queueDlqNudge());
+        Binding analyticsDlqBinding = BindingBuilder
+                .bind(deadLetterAnalyticsQueue)
+                .to(deadLetterExchange)
+                .with(properties.queueDlqAnalytics());
+
+        return new Declarables(
+                reportBinding,
+                nudgeBinding,
+                analyticsBinding,
+                reportDlqBinding,
+                nudgeDlqBinding,
+                analyticsDlqBinding
+        );
     }
 
     @Bean

--- a/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
+++ b/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
@@ -2,6 +2,9 @@ package com.withbuddy.onboarding.service;
 
 import com.withbuddy.auth.repository.UserRepository;
 import com.withbuddy.chat.service.ChatMessageService;
+import com.withbuddy.infrastructure.redis.RedisCacheKeys;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
+import com.withbuddy.infrastructure.redis.RedisCacheTtl;
 import com.withbuddy.onboarding.dto.OnboardingSuggestionItemResponse;
 import com.withbuddy.onboarding.dto.OnboardingSuggestionListResponse;
 import com.withbuddy.onboarding.entity.OnboardingSuggestion;
@@ -14,6 +17,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,31 +28,37 @@ public class OnboardingSuggestionService {
     private final UserRepository userRepository;
     private final OnboardingSuggestionRepository onboardingSuggestionRepository;
     private final ChatMessageService chatMessageService;
+    private final RedisCacheService redisCacheService;
 
     public OnboardingSuggestionListResponse getMyOnboardingSuggestions(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        LocalDate hireDate = user.getHireDate();
-        LocalDate today = LocalDate.now(KST);
-        int dayOffset = (int) ChronoUnit.DAYS.between(hireDate, today);
+        int dayOffset = getOrCacheDayOffset(user);
 
-        Long suggestionId = resolveSuggestionId(dayOffset);
+        Long suggestionId = getOrCacheQuickTapSuggestionId(dayOffset);
 
         if (suggestionId == null) {
             return new OnboardingSuggestionListResponse(List.of());
         }
 
         OnboardingSuggestion suggestion = onboardingSuggestionRepository.findById(suggestionId)
-                .orElseThrow(() -> new IllegalArgumentException("온보딩 제안을 찾을 수 없습니다."));
+                .orElse(null);
+
+        if (suggestion == null) {
+            return new OnboardingSuggestionListResponse(List.of());
+        }
 
         String content = replacePlaceholders(suggestion.getContent(), user.getName(), dayOffset);
 
-        chatMessageService.saveSuggestionMessageIfNotExists(
-                userId,
-                suggestion.getId(),
-                content
-        );
+        String nudgeSentKey = RedisCacheKeys.nudgeSent(userId, dayOffset);
+        if (redisCacheService.putIfAbsent(nudgeSentKey, "1", RedisCacheTtl.NUDGE_SENT)) {
+            chatMessageService.saveSuggestionMessageIfNotExists(
+                    userId,
+                    suggestion.getId(),
+                    content
+            );
+        }
 
         OnboardingSuggestionItemResponse response = new OnboardingSuggestionItemResponse(
                 suggestion.getTitle(),
@@ -58,6 +68,43 @@ public class OnboardingSuggestionService {
         );
 
         return new OnboardingSuggestionListResponse(List.of(response));
+    }
+
+    private int getOrCacheDayOffset(User user) {
+        String key = RedisCacheKeys.buddyDay(user.getId());
+        Optional<String> cached = redisCacheService.get(key);
+        if (cached.isPresent()) {
+            return Integer.parseInt(cached.get());
+        }
+
+        LocalDate hireDate = user.getHireDate();
+        LocalDate today = LocalDate.now(KST);
+        int dayOffset = (int) ChronoUnit.DAYS.between(hireDate, today);
+        redisCacheService.put(key, String.valueOf(dayOffset), RedisCacheTtl.BUDDY_DAY);
+        return dayOffset;
+    }
+
+    private Long getOrCacheQuickTapSuggestionId(int dayOffset) {
+        String key = RedisCacheKeys.quickTap(dayOffset);
+        Optional<String> cached = redisCacheService.get(key);
+        if (cached.isPresent()) {
+            return parseNullableLong(cached.get());
+        }
+
+        Long suggestionId = resolveSuggestionId(dayOffset);
+        if (suggestionId == null) {
+            return null;
+        }
+
+        redisCacheService.put(key, String.valueOf(suggestionId), RedisCacheTtl.QUICK_TAP);
+        return suggestionId;
+    }
+
+    private Long parseNullableLong(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return Long.parseLong(value);
     }
 
     private Long resolveSuggestionId(int dayOffset) {

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -29,6 +29,8 @@ jwt:
 ai:
   server:
     base-url: ${AI_SERVER_BASE_URL}
+    connect-timeout-ms: ${AI_SERVER_CONNECT_TIMEOUT_MS:5000}
+    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:20000}
 
 app:
   security:
@@ -41,8 +43,14 @@ app:
           active: ${STORAGE_API_KEY_ACTIVE:true}
   rabbitmq:
     exchange: ${RABBITMQ_EXCHANGE:withbuddy.exchange}
+    dlx-exchange: ${RABBITMQ_DLX_EXCHANGE:withbuddy.dlx}
     queue-report: ${RABBITMQ_QUEUE_REPORT:withbuddy.report}
+    queue-nudge: ${RABBITMQ_QUEUE_NUDGE:q.nudge}
+    queue-analytics: ${RABBITMQ_QUEUE_ANALYTICS:q.analytics}
     queue-dlq: ${RABBITMQ_QUEUE_DLQ:withbuddy.report.dlq}
+    queue-dlq-nudge: ${RABBITMQ_QUEUE_DLQ_NUDGE:q.dlq.nudge}
+    queue-dlq-analytics: ${RABBITMQ_QUEUE_DLQ_ANALYTICS:q.dlq.analytics}
+    nudge-ttl-ms: ${RABBITMQ_NUDGE_TTL_MS:86400000}
   storage:
     provider: ${STORAGE_PROVIDER:local}
     local-base-dir: ${STORAGE_LOCAL_BASE_DIR:storage-data}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -62,8 +62,14 @@ app:
           active: ${STORAGE_API_KEY_ACTIVE:true}
   rabbitmq:
     exchange: ${RABBITMQ_EXCHANGE:withbuddy.exchange}
+    dlx-exchange: ${RABBITMQ_DLX_EXCHANGE:withbuddy.dlx}
     queue-report: ${RABBITMQ_QUEUE_REPORT:withbuddy.report}
+    queue-nudge: ${RABBITMQ_QUEUE_NUDGE:q.nudge}
+    queue-analytics: ${RABBITMQ_QUEUE_ANALYTICS:q.analytics}
     queue-dlq: ${RABBITMQ_QUEUE_DLQ:withbuddy.report.dlq}
+    queue-dlq-nudge: ${RABBITMQ_QUEUE_DLQ_NUDGE:q.dlq.nudge}
+    queue-dlq-analytics: ${RABBITMQ_QUEUE_DLQ_ANALYTICS:q.dlq.analytics}
+    nudge-ttl-ms: ${RABBITMQ_NUDGE_TTL_MS:86400000}
   storage:
     provider: ${STORAGE_PROVIDER:local}
     local-base-dir: ${STORAGE_LOCAL_BASE_DIR:storage-data}

--- a/backend/src/test/java/com/withbuddy/benchmark/OnboardingCacheBenchmarkTest.java
+++ b/backend/src/test/java/com/withbuddy/benchmark/OnboardingCacheBenchmarkTest.java
@@ -1,0 +1,206 @@
+package com.withbuddy.benchmark;
+
+import com.withbuddy.auth.repository.UserRepository;
+import com.withbuddy.chat.service.ChatMessageService;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
+import com.withbuddy.onboarding.entity.OnboardingSuggestion;
+import com.withbuddy.onboarding.repository.OnboardingSuggestionRepository;
+import com.withbuddy.onboarding.service.OnboardingSuggestionService;
+import com.withbuddy.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Redis 도입 전후 성능 비교 벤치마크
+ *
+ * 측정 대상: OnboardingSuggestionService.getMyOnboardingSuggestions()
+ *
+ * [A] Before Redis
+ *     - get()          → 항상 MISS
+ *     - putIfAbsent()  → 항상 true
+ *     - 결과: 매 요청마다 user + suggestion + nudge(existsBy+save) 전체 DB 경로 실행
+ *
+ * [B] After Redis (Warm Cache)
+ *     - buddy:day / quicktap / nudge:sent 모두 캐시됨
+ *     - 결과: user + suggestion DB만 실행, nudge DB 쿼리 스킵
+ *
+ * DB 레이턴시 시뮬레이션: Thread.sleep(DB_LATENCY_MS)으로 실제 MySQL ~5ms 모사
+ * 외부 의존성 없음 — Redis/MySQL 없이 로컬 실행 가능
+ */
+class OnboardingCacheBenchmarkTest {
+
+    // ── 벤치마크 파라미터 ──────────────────────────────────────────────
+    private static final int  WARMUP_ITERS  = 10;
+    private static final int  MEASURE_ITERS = 200;
+    private static final long DB_LATENCY_MS = 5L;   // MySQL 평균 RTT 모사
+
+    // ── 테스트 픽스처 ──────────────────────────────────────────────────
+    private static final Long USER_ID       = 1L;
+    private static final int  DAY_OFFSET    = 5;    // 입사 5일차
+    private static final Long SUGGESTION_ID = 4L;   // resolveSuggestionId(5) == 4L
+
+    private UserRepository                userRepo;
+    private OnboardingSuggestionRepository suggestionRepo;
+    private ChatMessageService             chatService;
+
+    @BeforeEach
+    void setUpMocks() throws Exception {
+        userRepo      = mock(UserRepository.class);
+        suggestionRepo = mock(OnboardingSuggestionRepository.class);
+        chatService   = mock(ChatMessageService.class);
+
+        User mockUser = mock(User.class);
+        when(mockUser.getId()).thenReturn(USER_ID);
+        when(mockUser.getHireDate()).thenReturn(LocalDate.now().minusDays(DAY_OFFSET));
+        when(mockUser.getName()).thenReturn("테스트유저");
+
+        OnboardingSuggestion mockSuggestion = mock(OnboardingSuggestion.class);
+        when(mockSuggestion.getId()).thenReturn(SUGGESTION_ID);
+        when(mockSuggestion.getTitle()).thenReturn("입사 5일차 온보딩");
+        when(mockSuggestion.getContent()).thenReturn("{이름}님, 입사 {N}일이 지났습니다.");
+        when(mockSuggestion.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+        // ── DB 레이턴시 시뮬레이션 ──────────────────────────────────────
+        when(userRepo.findById(USER_ID)).thenAnswer(inv -> {
+            Thread.sleep(DB_LATENCY_MS);
+            return Optional.of(mockUser);
+        });
+        when(suggestionRepo.findById(SUGGESTION_ID)).thenAnswer(inv -> {
+            Thread.sleep(DB_LATENCY_MS);
+            return Optional.of(mockSuggestion);
+        });
+        // saveSuggestionMessageIfNotExists = existsBy + (optional) save
+        doAnswer(inv -> {
+            Thread.sleep(DB_LATENCY_MS);
+            return null;
+        }).when(chatService).saveSuggestionMessageIfNotExists(anyLong(), anyLong(), anyString());
+    }
+
+    // ── 메인 벤치마크 ─────────────────────────────────────────────────
+
+    @Test
+    void benchmark_before_and_after_redis() throws Exception {
+        long[] before = measure(buildNoCache());
+        long[] after  = measure(buildWarmCache());
+
+        printReport(before, after);
+    }
+
+    // ── RedisCacheService 구현 ─────────────────────────────────────────
+
+    /**
+     * Redis 없음 (Before).
+     * get()         → 항상 Optional.empty()
+     * putIfAbsent() → 항상 true  (nudge 중복 방지 없음 → 매번 DB 호출)
+     */
+    private RedisCacheService buildNoCache() {
+        RedisCacheService svc = mock(RedisCacheService.class);
+        when(svc.get(anyString())).thenReturn(Optional.empty());
+        when(svc.putIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(true);
+        return svc;
+    }
+
+    /**
+     * Warm Cache (After).
+     * buddy:day / quicktap / nudge:sent 모두 사전 적재.
+     * putIfAbsent("nudge:sent:...") → false (이미 존재)
+     *   → chatService.saveSuggestionMessageIfNotExists() 호출 안 함
+     */
+    private RedisCacheService buildWarmCache() {
+        Map<String, String> store = new ConcurrentHashMap<>();
+        store.put("buddy:day:"  + USER_ID,                    String.valueOf(DAY_OFFSET));
+        store.put("quicktap:"   + DAY_OFFSET,                 String.valueOf(SUGGESTION_ID));
+        store.put("nudge:sent:" + USER_ID + ":" + DAY_OFFSET, "1");
+
+        RedisCacheService svc = mock(RedisCacheService.class);
+        when(svc.get(anyString())).thenAnswer(inv ->
+            Optional.ofNullable(store.get((String) inv.getArgument(0))));
+        when(svc.putIfAbsent(anyString(), anyString(), any(Duration.class))).thenAnswer(inv -> {
+            String key = inv.getArgument(0);
+            String val = inv.getArgument(1);
+            return store.putIfAbsent(key, val) == null; // 이미 존재 → false
+        });
+        return svc;
+    }
+
+    // ── 실행 ──────────────────────────────────────────────────────────
+
+    private long[] measure(RedisCacheService redis) throws Exception {
+        OnboardingSuggestionService service =
+            new OnboardingSuggestionService(userRepo, suggestionRepo, chatService, redis);
+
+        // 웜업 (JIT 컴파일 안정화)
+        for (int i = 0; i < WARMUP_ITERS; i++) {
+            service.getMyOnboardingSuggestions(USER_ID);
+        }
+
+        long[] times = new long[MEASURE_ITERS];
+        for (int i = 0; i < MEASURE_ITERS; i++) {
+            long start = System.nanoTime();
+            service.getMyOnboardingSuggestions(USER_ID);
+            times[i] = (System.nanoTime() - start) / 1_000_000; // ns → ms
+        }
+        return times;
+    }
+
+    // ── 결과 출력 ─────────────────────────────────────────────────────
+
+    private void printReport(long[] before, long[] after) {
+        long avgBefore = avg(before);
+        long avgAfter  = avg(after);
+        long saved     = avgBefore - avgAfter;
+        double pct     = (double) saved / avgBefore * 100.0;
+
+        System.out.println();
+        System.out.println("╔═══════════════════════════════════════════════════════════════════════╗");
+        System.out.println("║        Redis 도입 전후 성능 비교 — OnboardingSuggestion               ║");
+        System.out.printf ("║        DB 레이턴시 %dms 시뮬레이션  /  측정 %d회                       ║%n",
+                DB_LATENCY_MS, MEASURE_ITERS);
+        System.out.println("╠══════════════╦══════════╦══════════╦══════════╦══════════╦════════════╣");
+        System.out.println("║   시나리오    ║   AVG    ║   P50    ║   P95    ║   P99    ║ DB 쿼리 수 ║");
+        System.out.println("╠══════════════╬══════════╬══════════╬══════════╬══════════╬════════════╣");
+        printRow("Before (A)  ", before, "3 쿼리");
+        printRow("After  (B)  ", after,  "2 쿼리");
+        System.out.println("╠══════════════╩══════════╩══════════╩══════════╩══════════╩════════════╣");
+        System.out.printf ("║  개선: %dms → %dms  |  요청당 ~%dms 절감  |  %.1f%% 빨라짐              %n",
+                avgBefore, avgAfter, saved, pct);
+        System.out.println("╠═══════════════════════════════════════════════════════════════════════╣");
+        System.out.println("║  [절감 근거]                                                          ║");
+        System.out.println("║    nudge:sent SETNX HIT → saveSuggestionMessageIfNotExists() 스킵     ║");
+        System.out.println("║    (chatMessageRepository.existsBy + optional save 생략)              ║");
+        System.out.println("╠═══════════════════════════════════════════════════════════════════════╣");
+        System.out.println("║  [미절감 — 항상 DB 호출]                                              ║");
+        System.out.println("║    userRepo.findById()        → user:profile 읽기 경로 미구현          ║");
+        System.out.println("║    suggestionRepo.findById()  → suggestion 캐싱 미구현                 ║");
+        System.out.println("╠═══════════════════════════════════════════════════════════════════════╣");
+        System.out.println("║  [추가 개선 가능]                                                     ║");
+        System.out.println("║    user:profile / quicktap suggestion 읽기 캐싱 시 3쿼리 → 0쿼리      ║");
+        System.out.println("╚═══════════════════════════════════════════════════════════════════════╝");
+        System.out.println();
+    }
+
+    private void printRow(String label, long[] times, String dbNote) {
+        long[] sorted = Arrays.copyOf(times, times.length);
+        Arrays.sort(sorted);
+        System.out.printf("║ %-12s ║ %6dms ║ %6dms ║ %6dms ║ %6dms ║ %-10s ║%n",
+            label,
+            avg(times),
+            sorted[sorted.length / 2],
+            sorted[(int) (sorted.length * 0.95)],
+            sorted[(int) (sorted.length * 0.99)],
+            dbNote);
+    }
+
+    private long avg(long[] times) {
+        return (long) Arrays.stream(times).average().orElse(0);
+    }
+}


### PR DESCRIPTION
## 목적
main 배포를 위해 develop 계열 변경 중 필요한 항목을 cherry-pick하여 반영합니다.

## 포함 커밋
- fix(chat): chat/messages 500 방지 및 인증 예외 401 처리
- chore(ai): AI client timeout 설정 환경변수화
- chore(infra): 보안/메시징 설정 정리
- test(benchmark): 온보딩 캐시 벤치마크 테스트 추가

## 참고
- `feat(auth)` 커밋(`83b74bd`)은 현재 `main`에 이미 동일 내용이 포함되어 cherry-pick 시 empty로 판단되어 skip 처리되었습니다.
- 본 PR은 생성까지만 진행했습니다.