### PR TITLE
feat: user:profile read path 추가와 onbording suggestion 매핑 수정

### DIFF
--- a/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
+++ b/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
@@ -145,11 +145,11 @@ public class OnboardingSuggestionService {
     }
 
     private Long resolveSuggestionId(int dayOffset) {
-        // onboarding_suggestions 시드(day_offset: 1, 4, 8, 31)에 맞춘 단계 매핑
-        if (dayOffset >= 31) return 4L;   // 입사 31일차 안내
-        if (dayOffset >= 8) return 3L;    // 입사 8일차 안내
-        if (dayOffset >= 4) return 2L;    // 입사 4일차 안내
-        if (dayOffset >= 1) return 1L;    // 입사 1일차 안내
+        if (dayOffset >= -7 && dayOffset <= -4) return 1L;
+        if (dayOffset >= -3 && dayOffset <= -1) return 2L;
+        if (dayOffset == 0) return 3L;
+        if (dayOffset >= 1 && dayOffset <= 7) return 4L;
+        if (dayOffset >= 8) return 5L;
         return null;
     }
 

--- a/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
+++ b/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
@@ -2,6 +2,8 @@ package com.withbuddy.onboarding.service;
 
 import com.withbuddy.auth.repository.UserRepository;
 import com.withbuddy.chat.service.ChatMessageService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.withbuddy.infrastructure.redis.RedisCacheKeys;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.infrastructure.redis.RedisCacheTtl;
@@ -29,12 +31,12 @@ public class OnboardingSuggestionService {
     private final OnboardingSuggestionRepository onboardingSuggestionRepository;
     private final ChatMessageService chatMessageService;
     private final RedisCacheService redisCacheService;
+    private final ObjectMapper objectMapper;
 
     public OnboardingSuggestionListResponse getMyOnboardingSuggestions(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        UserProfile userProfile = getUserProfile(userId);
 
-        int dayOffset = getOrCacheDayOffset(user);
+        int dayOffset = getOrCacheDayOffset(userId, userProfile.hireDate());
 
         Long suggestionId = getOrCacheQuickTapSuggestionId(dayOffset);
 
@@ -49,7 +51,7 @@ public class OnboardingSuggestionService {
             return new OnboardingSuggestionListResponse(List.of());
         }
 
-        String content = replacePlaceholders(suggestion.getContent(), user.getName(), dayOffset);
+        String content = replacePlaceholders(suggestion.getContent(), userProfile.name(), dayOffset);
 
         String nudgeSentKey = RedisCacheKeys.nudgeSent(userId, dayOffset);
         if (redisCacheService.putIfAbsent(nudgeSentKey, "1", RedisCacheTtl.NUDGE_SENT)) {
@@ -70,14 +72,49 @@ public class OnboardingSuggestionService {
         return new OnboardingSuggestionListResponse(List.of(response));
     }
 
-    private int getOrCacheDayOffset(User user) {
-        String key = RedisCacheKeys.buddyDay(user.getId());
+    private UserProfile getUserProfile(Long userId) {
+        Optional<UserProfile> cached = getCachedUserProfile(userId);
+        if (cached.isPresent()) {
+            return cached.get();
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        return new UserProfile(user.getName(), user.getHireDate());
+    }
+
+    private Optional<UserProfile> getCachedUserProfile(Long userId) {
+        Optional<String> cached = redisCacheService.get(RedisCacheKeys.userProfile(userId));
+        if (cached.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(cached.get());
+            JsonNode nameNode = root.get("name");
+            JsonNode hireDateNode = root.get("hireDate");
+
+            if (nameNode == null || nameNode.asText().isBlank()
+                    || hireDateNode == null || hireDateNode.asText().isBlank()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new UserProfile(
+                    nameNode.asText(),
+                    LocalDate.parse(hireDateNode.asText())
+            ));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private int getOrCacheDayOffset(Long userId, LocalDate hireDate) {
+        String key = RedisCacheKeys.buddyDay(userId);
         Optional<String> cached = redisCacheService.get(key);
         if (cached.isPresent()) {
             return Integer.parseInt(cached.get());
         }
 
-        LocalDate hireDate = user.getHireDate();
         LocalDate today = LocalDate.now(KST);
         int dayOffset = (int) ChronoUnit.DAYS.between(hireDate, today);
         redisCacheService.put(key, String.valueOf(dayOffset), RedisCacheTtl.BUDDY_DAY);
@@ -108,11 +145,11 @@ public class OnboardingSuggestionService {
     }
 
     private Long resolveSuggestionId(int dayOffset) {
-        if (dayOffset >= -7 && dayOffset <= -4) return 1L;
-        if (dayOffset >= -3 && dayOffset <= -1) return 2L;
-        if (dayOffset == 0) return 3L;
-        if (dayOffset >= 1 && dayOffset <= 7) return 4L;
-        if (dayOffset >= 8) return 5L;
+        // onboarding_suggestions 시드(day_offset: 1, 4, 8, 31)에 맞춘 단계 매핑
+        if (dayOffset >= 31) return 4L;   // 입사 31일차 안내
+        if (dayOffset >= 8) return 3L;    // 입사 8일차 안내
+        if (dayOffset >= 4) return 2L;    // 입사 4일차 안내
+        if (dayOffset >= 1) return 1L;    // 입사 1일차 안내
         return null;
     }
 
@@ -120,5 +157,8 @@ public class OnboardingSuggestionService {
         return content
                 .replace("{이름}", userName)
                 .replace("{N}", String.valueOf(Math.abs(dayOffset)));
+    }
+
+    private record UserProfile(String name, LocalDate hireDate) {
     }
 }

--- a/backend/src/test/java/com/withbuddy/benchmark/OnboardingCacheBenchmarkTest.java
+++ b/backend/src/test/java/com/withbuddy/benchmark/OnboardingCacheBenchmarkTest.java
@@ -2,6 +2,7 @@ package com.withbuddy.benchmark;
 
 import com.withbuddy.auth.repository.UserRepository;
 import com.withbuddy.chat.service.ChatMessageService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.onboarding.entity.OnboardingSuggestion;
 import com.withbuddy.onboarding.repository.OnboardingSuggestionRepository;
@@ -30,8 +31,8 @@ import static org.mockito.Mockito.*;
  *     - 결과: 매 요청마다 user + suggestion + nudge(existsBy+save) 전체 DB 경로 실행
  *
  * [B] After Redis (Warm Cache)
- *     - buddy:day / quicktap / nudge:sent 모두 캐시됨
- *     - 결과: user + suggestion DB만 실행, nudge DB 쿼리 스킵
+ *     - user:profile / buddy:day / quicktap / nudge:sent 모두 캐시됨
+ *     - 결과: suggestion DB만 실행, user + nudge DB 쿼리 스킵
  *
  * DB 레이턴시 시뮬레이션: Thread.sleep(DB_LATENCY_MS)으로 실제 MySQL ~5ms 모사
  * 외부 의존성 없음 — Redis/MySQL 없이 로컬 실행 가능
@@ -46,7 +47,7 @@ class OnboardingCacheBenchmarkTest {
     // ── 테스트 픽스처 ──────────────────────────────────────────────────
     private static final Long USER_ID       = 1L;
     private static final int  DAY_OFFSET    = 5;    // 입사 5일차
-    private static final Long SUGGESTION_ID = 4L;   // resolveSuggestionId(5) == 4L
+    private static final Long SUGGESTION_ID = 2L;   // resolveSuggestionId(5) == 2L
 
     private UserRepository                userRepo;
     private OnboardingSuggestionRepository suggestionRepo;
@@ -111,12 +112,13 @@ class OnboardingCacheBenchmarkTest {
 
     /**
      * Warm Cache (After).
-     * buddy:day / quicktap / nudge:sent 모두 사전 적재.
+     * user:profile / buddy:day / quicktap / nudge:sent 모두 사전 적재.
      * putIfAbsent("nudge:sent:...") → false (이미 존재)
      *   → chatService.saveSuggestionMessageIfNotExists() 호출 안 함
      */
     private RedisCacheService buildWarmCache() {
         Map<String, String> store = new ConcurrentHashMap<>();
+        store.put("user:profile:" + USER_ID, "{\"name\":\"테스트유저\",\"hireDate\":\"" + LocalDate.now().minusDays(DAY_OFFSET) + "\"}");
         store.put("buddy:day:"  + USER_ID,                    String.valueOf(DAY_OFFSET));
         store.put("quicktap:"   + DAY_OFFSET,                 String.valueOf(SUGGESTION_ID));
         store.put("nudge:sent:" + USER_ID + ":" + DAY_OFFSET, "1");
@@ -136,7 +138,7 @@ class OnboardingCacheBenchmarkTest {
 
     private long[] measure(RedisCacheService redis) throws Exception {
         OnboardingSuggestionService service =
-            new OnboardingSuggestionService(userRepo, suggestionRepo, chatService, redis);
+            new OnboardingSuggestionService(userRepo, suggestionRepo, chatService, redis, new ObjectMapper());
 
         // 웜업 (JIT 컴파일 안정화)
         for (int i = 0; i < WARMUP_ITERS; i++) {
@@ -179,11 +181,10 @@ class OnboardingCacheBenchmarkTest {
         System.out.println("║    (chatMessageRepository.existsBy + optional save 생략)              ║");
         System.out.println("╠═══════════════════════════════════════════════════════════════════════╣");
         System.out.println("║  [미절감 — 항상 DB 호출]                                              ║");
-        System.out.println("║    userRepo.findById()        → user:profile 읽기 경로 미구현          ║");
         System.out.println("║    suggestionRepo.findById()  → suggestion 캐싱 미구현                 ║");
         System.out.println("╠═══════════════════════════════════════════════════════════════════════╣");
         System.out.println("║  [추가 개선 가능]                                                     ║");
-        System.out.println("║    user:profile / quicktap suggestion 읽기 캐싱 시 3쿼리 → 0쿼리      ║");
+        System.out.println("║    suggestion 읽기 캐싱 시 1쿼리 → 0쿼리                               ║");
         System.out.println("╚═══════════════════════════════════════════════════════════════════════╝");
         System.out.println();
     }


### PR DESCRIPTION
feat: user:profile read path 추가와 onbording suggestion 매핑 수정

미구현: user:profile 캐시는 쓰기만 하고 읽지 않음
AuthService.java:66 에서 로그인 시 user:profile:{userId}를 30분 TTL로 저장하지만, 백엔드 전체에서 이 캐시를 읽는 코드가 없음. OnboardingSuggestionService는 여전히userRepository.findById()로 DB를 직접 조회. (벤치마크 주석에도 "user:profile 읽기 경로 미구현"으로 명시됨.)