### PR TITLE
fix: remove duplicate jwt exception handler

### DIFF
--- a/backend/src/main/java/com/withbuddy/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/withbuddy/global/exception/GlobalExceptionHandler.java
@@ -93,27 +93,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
     }
 
-    @ExceptionHandler(JwtException.class)
-    public ResponseEntity<ErrorResponse> handleJwtException(
-            JwtException e,
-            HttpServletRequest request
-    ) {
-        List<FieldValidationError> errors = List.of(
-                new FieldValidationError("token", "유효하지 않은 토큰입니다. 다시 로그인해 주세요.")
-        );
-
-        ErrorResponse response = new ErrorResponse(
-                OffsetDateTime.now(ZoneOffset.UTC).toString(),
-                HttpStatus.UNAUTHORIZED.value(),
-                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
-                "INVALID_TOKEN",
-                errors,
-                request.getRequestURI()
-        );
-
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
-    }
-
     @ExceptionHandler(SessionNotActiveException.class)
     public ResponseEntity<ErrorResponse> handleSessionNotActiveException(
             SessionNotActiveException e,


### PR DESCRIPTION
## Summary
- Remove the duplicated `handleJwtException(JwtException, HttpServletRequest)` method from `GlobalExceptionHandler`.
- Keep the remaining JWT handler that logs invalid token failures.

## Verification
- `./gradlew.bat clean compileJava`