### PR TITLE
release: 비동기 AI PENDING 처리 반영

### DIFF
--- a/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageController.java
@@ -5,6 +5,7 @@ import com.withbuddy.activity.service.UserActivityLogService;
 import com.withbuddy.chat.dto.ChatMessageCreateResponse;
 import com.withbuddy.chat.dto.ChatMessageListResponse;
 import com.withbuddy.chat.dto.ChatMessageRequest;
+import com.withbuddy.chat.dto.ChatMessageStatusResponse;
 import com.withbuddy.chat.service.ChatMessageQueryService;
 import com.withbuddy.chat.service.ChatMessageService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +24,7 @@ import java.util.Map;
 @RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
 @Tag(name = "Ai", description = "버디 채팅 API")
-public class ChatMessageController {
+public class ChatMessageController implements ChatMessageControllerDocs {
 
     private final ChatMessageService chatMessageService;
     private final ChatMessageQueryService chatMessageQueryService;
@@ -75,5 +76,14 @@ public class ChatMessageController {
             @RequestHeader(value = "Authorization", required = false) String bearerToken
     ) {
         return userActivityLogService.saveQuickQuestionClick(bearerToken);
+    }
+
+    @GetMapping("/messages/{questionId}/status")
+    @ResponseStatus(HttpStatus.OK)
+    public ChatMessageStatusResponse getMessageStatus(
+            @RequestHeader(value = "Authorization", required = false) String bearerToken,
+            @PathVariable Long questionId
+    ) {
+        return chatMessageQueryService.getMessageStatus(bearerToken, questionId);
     }
 }

--- a/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageControllerDocs.java
+++ b/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageControllerDocs.java
@@ -1,0 +1,137 @@
+package com.withbuddy.chat.controller;
+
+import com.withbuddy.activity.dto.LogResponse;
+import com.withbuddy.chat.dto.ChatMessageCreateResponse;
+import com.withbuddy.chat.dto.ChatMessageListResponse;
+import com.withbuddy.chat.dto.ChatMessageRequest;
+import com.withbuddy.chat.dto.ChatMessageStatusResponse;
+import com.withbuddy.global.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "Chat", description = "버디 채팅 API — 수습사원이 AI 버디와 대화하고 온보딩 정보를 얻는 핵심 채널")
+public interface ChatMessageControllerDocs {
+
+    @Operation(
+        summary = "메시지 전송 및 AI 답변 요청",
+        description = """
+            [목적] 수습사원의 질문을 저장하고 AI 서버(RAG)에 답변을 요청한다.
+            [베네핏] 사내 문서 기반의 정확한 AI 답변을 즉시 제공해 수습사원이 사수나 HR 없이도 \
+            온보딩 관련 정보를 자기 주도적으로 해결할 수 있다. \
+            답변과 함께 관련 문서 ID가 반환되어 출처를 추적할 수 있다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "메시지 전송 및 AI 답변 생성 성공",
+                content = @Content(schema = @Schema(implementation = ChatMessageCreateResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패 — 유효하지 않은 토큰",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "504", description = "AI 서버 응답 시간 초과",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ChatMessageCreateResponse sendMessage(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String bearerToken,
+            ChatMessageRequest request
+    );
+
+    @Operation(
+        summary = "대화 이력 조회",
+        description = """
+            [목적] 로그인한 사용자의 전체 또는 특정 날짜의 대화 이력을 조회한다.
+            [베네핏] 이전 대화 내용을 복원해 연속적인 대화 경험을 제공한다. \
+            날짜 필터(date 파라미터)를 사용하면 특정 일자의 대화만 조회할 수 있어 \
+            온보딩 진행 흐름을 일자별로 파악할 수 있다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "대화 이력 조회 성공",
+                content = @Content(schema = @Schema(implementation = ChatMessageListResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패 — 유효하지 않은 토큰",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ChatMessageListResponse getMessages(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String bearerToken,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
+
+    @Operation(
+        summary = "채팅 세션 시작 로깅",
+        description = """
+            [목적] 수습사원이 채팅을 시작한 시점을 기록한다. 하루 1회만 기록된다.
+            [베네핏] 수습사원의 챗봇 활용 빈도와 패턴을 분석해 온보딩 참여도를 측정할 수 있다. \
+            이 데이터를 기반으로 챗봇 미활용자를 조기에 식별하고 개입할 수 있다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "세션 시작 최초 기록"),
+        @ApiResponse(responseCode = "200", description = "이미 오늘 기록됨 (중복 로깅 방지)"),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<LogResponse> saveSessionStart(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String bearerToken
+    );
+
+    @Operation(
+        summary = "추천 질문 목록 조회",
+        description = """
+            [목적] 수습사원에게 챗봇에서 물어볼 수 있는 대표 질문 목록을 제공한다.
+            [베네핏] 어떤 질문을 해야 할지 모르는 수습사원의 진입 장벽을 낮추고 \
+            챗봇 첫 사용을 유도한다. 추천 질문 클릭만으로 유의미한 답변을 얻을 수 있어 \
+            초기 온보딩 완료율을 높이는 데 기여한다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "추천 질문 목록 반환"),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    Map<String, List<Map<String, String>>> getQuickQuestions(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String bearerToken
+    );
+
+    @Operation(
+        summary = "추천 질문 클릭 로깅",
+        description = """
+            [목적] 수습사원이 추천 질문을 클릭한 행동을 기록한다.
+            [베네핏] 어떤 추천 질문이 자주 선택되는지 데이터를 수집해 \
+            콘텐츠 팀이 추천 질문 목록을 지속적으로 개선할 수 있다. \
+            클릭 데이터는 온보딩 콘텐츠 효과 측정의 지표로 활용된다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "클릭 로그 기록 성공"),
+        @ApiResponse(responseCode = "401", description = "인증 실패",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    LogResponse saveQuickQuestionClick(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String bearerToken
+    );
+
+    @Operation(
+        summary = "AI 답변 처리 상태 조회",
+        description = """
+            [목적] 10초 초과로 비동기 처리 중인 질문의 상태와 완료된 답변을 조회한다.
+            [베네핏] 클라이언트가 PENDING 응답 이후 폴링으로 완료 여부를 확인해 \
+            긴 AI 답변 생성 중에도 화면 흐름을 유지할 수 있다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "상태 조회 성공 (PENDING / COMPLETED / TIMEOUT)",
+                content = @Content(schema = @Schema(implementation = ChatMessageStatusResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패 또는 접근 권한 없음",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ChatMessageStatusResponse getMessageStatus(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false) String bearerToken,
+            @PathVariable Long questionId
+    );
+}

--- a/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageCreateResponse.java
+++ b/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageCreateResponse.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class ChatMessageCreateResponse {
     private ChatMessageResponse question;
     private ChatMessageResponse answer;
+    private String status;
 }

--- a/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageStatusResponse.java
+++ b/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageStatusResponse.java
@@ -1,0 +1,11 @@
+package com.withbuddy.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatMessageStatusResponse {
+    private String status;              // PENDING, COMPLETED, TIMEOUT
+    private ChatMessageResponse answer; // COMPLETED일 때만 값이 있음, 나머지는 null
+}

--- a/backend/src/main/java/com/withbuddy/chat/service/AsyncAiCallService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/AsyncAiCallService.java
@@ -1,0 +1,104 @@
+package com.withbuddy.chat.service;
+
+import com.withbuddy.infrastructure.ai.dto.AiAnswerServerRequest;
+import com.withbuddy.infrastructure.ai.dto.AiAnswerServerResponse;
+import com.withbuddy.infrastructure.ai.exception.AiTimeoutException;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
+import com.withbuddy.infrastructure.redis.RedisCacheTtl;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.net.http.HttpTimeoutException;
+
+@Service
+@Slf4j
+public class AsyncAiCallService {
+
+    private final RestClient asyncAiRestClient;
+    private final ChatAnswerSaveService chatAnswerSaveService;
+    private final RedisCacheService redisCacheService;
+
+    public AsyncAiCallService(
+            @Qualifier("asyncAiRestClient") RestClient asyncAiRestClient,
+            ChatAnswerSaveService chatAnswerSaveService,
+            RedisCacheService redisCacheService
+    ) {
+        this.asyncAiRestClient = asyncAiRestClient;
+        this.chatAnswerSaveService = chatAnswerSaveService;
+        this.redisCacheService = redisCacheService;
+    }
+
+    @Async("aiCallExecutor")
+    public void callAndSaveAnswer(Long questionId, Long userId, AiAnswerServerRequest aiRequest) {
+        log.info("비동기 AI 호출 시작: questionId={}", questionId);
+        try {
+            AiAnswerServerResponse aiResponse = requestAnswer(aiRequest);
+            chatAnswerSaveService.saveAsyncAnswer(questionId, userId, aiResponse);
+            log.info("비동기 AI 호출 완료: questionId={}", questionId);
+        } catch (Exception e) {
+            log.error("비동기 AI 호출 실패: questionId={}", questionId, e);
+            redisCacheService.put(ragStatusKey(questionId), "TIMEOUT", RedisCacheTtl.RAG_STATUS);
+        }
+    }
+
+    private AiAnswerServerResponse requestAnswer(AiAnswerServerRequest request) {
+        try {
+            AiAnswerServerResponse response = asyncAiRestClient.post()
+                    .uri("/internal/ai/answer")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(request)
+                    .retrieve()
+                    .body(AiAnswerServerResponse.class);
+
+            if (response == null) {
+                throw new IllegalStateException("AI 서버 응답이 비어 있습니다.");
+            }
+            return response;
+
+        } catch (HttpClientErrorException e) {
+            log.error("비동기 AI 호출 오류: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new RuntimeException("AI 서버 호출 중 오류가 발생했습니다.", e);
+
+        } catch (ResourceAccessException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof SocketTimeoutException || cause instanceof HttpTimeoutException) {
+                log.warn("비동기 AI timeout (55s 초과)", e);
+                throw new AiTimeoutException("비동기 AI 응답 시간이 초과되었습니다.", e);
+            }
+            if (cause instanceof ConnectException || cause instanceof UnknownHostException) {
+                log.error("비동기 AI 서버 연결 실패", e);
+                throw new RuntimeException("AI 서버 연결에 실패했습니다.", e);
+            }
+            log.error("비동기 AI 네트워크 오류", e);
+            throw new RuntimeException("AI 서버 호출 중 네트워크 오류가 발생했습니다.", e);
+
+        } catch (RestClientException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof SocketTimeoutException || cause instanceof HttpTimeoutException) {
+                log.warn("비동기 AI timeout (RestClientException)", e);
+                throw new AiTimeoutException("비동기 AI 응답 시간이 초과되었습니다.", e);
+            }
+            log.error("비동기 AI 호출 실패", e);
+            throw new RuntimeException("AI 서버 호출 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    static String ragStatusKey(Long questionId) {
+        return "rag:status:" + questionId;
+    }
+
+    static String ragAnswerKey(Long questionId) {
+        return "rag:answer:" + questionId;
+    }
+}

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatAnswerSaveService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatAnswerSaveService.java
@@ -54,10 +54,7 @@ public class ChatAnswerSaveService {
         MessageType answerMessageType = aiResponse.getMessageType();
         List<Long> answerDocumentIds = filterExistingDocumentIds(extractDocumentIds(aiResponse));
         ChatMessage savedAnswerMessage = saveAnswerMessage(userId, answerMessageType, aiResponse.getContent(), answerDocumentIds);
-
-        ChatMessage questionMessage = chatMessageRepository.findById(questionId)
-                .orElseThrow(() -> new IllegalStateException("질문 메시지를 찾을 수 없습니다: " + questionId));
-        saveConversationPair(userId, questionMessage.getContent(), savedAnswerMessage.getContent());
+        saveConversationAnswer(userId, savedAnswerMessage.getContent());
 
         redisCacheService.put(ragAnswerIdKey(questionId), String.valueOf(savedAnswerMessage.getId()), RedisCacheTtl.RAG_STATUS);
         redisCacheService.put(ragStatusKey(questionId), "COMPLETED", RedisCacheTtl.RAG_STATUS);
@@ -112,12 +109,9 @@ public class ChatAnswerSaveService {
         return documentIds.stream().filter(existingIds::contains).toList();
     }
 
-    private void saveConversationPair(Long userId, String userQuestion, String assistantAnswer) {
+    private void saveConversationAnswer(Long userId, String assistantAnswer) {
         String key = RedisCacheKeys.conversation(String.valueOf(userId));
-        List<ConversationTurn> turns = List.of(
-                new ConversationTurn("user", userQuestion),
-                new ConversationTurn("assistant", assistantAnswer)
-        );
+        List<ConversationTurn> turns = List.of(new ConversationTurn("assistant", assistantAnswer));
         writeConversationTurnsWithRecovery(key, turns);
     }
 

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatAnswerSaveService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatAnswerSaveService.java
@@ -1,0 +1,164 @@
+package com.withbuddy.chat.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.withbuddy.chat.entity.ChatMessage;
+import com.withbuddy.chat.entity.ChatMessageDocument;
+import com.withbuddy.chat.entity.MessageType;
+import com.withbuddy.chat.entity.SenderType;
+import com.withbuddy.chat.repository.ChatMessageDocumentRepository;
+import com.withbuddy.chat.repository.ChatMessageRepository;
+import com.withbuddy.infrastructure.ai.dto.AiAnswerServerResponse;
+import com.withbuddy.infrastructure.redis.RedisCacheKeys;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
+import com.withbuddy.infrastructure.redis.RedisCacheTtl;
+import com.withbuddy.infrastructure.ai.dto.ConversationTurn;
+import com.withbuddy.storage.entity.Document;
+import com.withbuddy.storage.repository.DocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 비동기 AI 답변 저장 서비스.
+ * ChatMessageService ↔ AsyncAiCallService 순환 의존을 방지하기 위해
+ * 저장 책임을 별도 클래스로 분리했습니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatAnswerSaveService {
+
+    private static final int MAX_HISTORY_MESSAGES = 10;
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageDocumentRepository chatMessageDocumentRepository;
+    private final DocumentRepository documentRepository;
+    private final RedisCacheService redisCacheService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void saveAsyncAnswer(Long questionId, Long userId, AiAnswerServerResponse aiResponse) {
+        if (!questionId.equals(aiResponse.getQuestionId())) {
+            log.warn("비동기 답변 저장 취소: questionId 불일치. expected={}, actual={}", questionId, aiResponse.getQuestionId());
+            redisCacheService.put(ragStatusKey(questionId), "TIMEOUT", RedisCacheTtl.RAG_STATUS);
+            return;
+        }
+
+        MessageType answerMessageType = aiResponse.getMessageType();
+        List<Long> answerDocumentIds = filterExistingDocumentIds(extractDocumentIds(aiResponse));
+        ChatMessage savedAnswerMessage = saveAnswerMessage(userId, answerMessageType, aiResponse.getContent(), answerDocumentIds);
+
+        ChatMessage questionMessage = chatMessageRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalStateException("질문 메시지를 찾을 수 없습니다: " + questionId));
+        saveConversationPair(userId, questionMessage.getContent(), savedAnswerMessage.getContent());
+
+        redisCacheService.put(ragAnswerIdKey(questionId), String.valueOf(savedAnswerMessage.getId()), RedisCacheTtl.RAG_STATUS);
+        redisCacheService.put(ragStatusKey(questionId), "COMPLETED", RedisCacheTtl.RAG_STATUS);
+    }
+
+    static String ragStatusKey(Long questionId) {
+        return "rag:status:" + questionId;
+    }
+
+    static String ragAnswerIdKey(Long questionId) {
+        return "rag:answer:" + questionId;
+    }
+
+    private ChatMessage saveAnswerMessage(Long userId, MessageType type, String content, List<Long> documentIds) {
+        ChatMessage answerMessage = new ChatMessage(userId, null, SenderType.BOT, type, content);
+        ChatMessage saved = chatMessageRepository.save(answerMessage);
+        saveDocumentMappings(saved.getId(), documentIds);
+        return saved;
+    }
+
+    private void saveDocumentMappings(Long chatMessageId, List<Long> documentIds) {
+        if (documentIds == null || documentIds.isEmpty()) {
+            return;
+        }
+        List<ChatMessageDocument> mappings = documentIds.stream()
+                .map(documentId -> ChatMessageDocument.builder()
+                        .chatMessageId(chatMessageId)
+                        .documentId(documentId)
+                        .build())
+                .toList();
+        chatMessageDocumentRepository.saveAll(mappings);
+    }
+
+    private List<Long> extractDocumentIds(AiAnswerServerResponse aiResponse) {
+        if (aiResponse.getDocuments() == null || aiResponse.getDocuments().isEmpty()) {
+            return List.of();
+        }
+        return aiResponse.getDocuments().stream()
+                .map(AiAnswerServerResponse.DocumentRef::getDocumentId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private List<Long> filterExistingDocumentIds(List<Long> documentIds) {
+        if (documentIds == null || documentIds.isEmpty()) {
+            return List.of();
+        }
+        Set<Long> existingIds = documentRepository.findByIdInAndIsActiveTrue(documentIds).stream()
+                .map(Document::getId)
+                .collect(Collectors.toSet());
+        return documentIds.stream().filter(existingIds::contains).toList();
+    }
+
+    private void saveConversationPair(Long userId, String userQuestion, String assistantAnswer) {
+        String key = RedisCacheKeys.conversation(String.valueOf(userId));
+        List<ConversationTurn> turns = List.of(
+                new ConversationTurn("user", userQuestion),
+                new ConversationTurn("assistant", assistantAnswer)
+        );
+        writeConversationTurnsWithRecovery(key, turns);
+    }
+
+    private void writeConversationTurnsWithRecovery(String key, List<ConversationTurn> turns) {
+        try {
+            writeConversationTurns(key, turns);
+        } catch (RuntimeException ex) {
+            if (isRedisWrongType(ex)) {
+                redisCacheService.delete(key);
+                writeConversationTurns(key, turns);
+                return;
+            }
+            throw ex;
+        }
+    }
+
+    private void writeConversationTurns(String key, List<ConversationTurn> turns) {
+        for (ConversationTurn turn : turns) {
+            writeConversationTurn(key, turn);
+        }
+        redisCacheService.listTrim(key, -MAX_HISTORY_MESSAGES, -1);
+        redisCacheService.expire(key, RedisCacheTtl.CONVERSATION);
+    }
+
+    private void writeConversationTurn(String key, ConversationTurn turn) {
+        try {
+            redisCacheService.listRightPush(key, objectMapper.writeValueAsString(turn));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("대화 이력 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    private boolean isRedisWrongType(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && message.contains("WRONGTYPE")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageQueryService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageQueryService.java
@@ -2,6 +2,7 @@ package com.withbuddy.chat.service;
 
 import com.withbuddy.chat.dto.ChatMessageListResponse;
 import com.withbuddy.chat.dto.ChatMessageResponse;
+import com.withbuddy.chat.dto.ChatMessageStatusResponse;
 import com.withbuddy.chat.entity.ChatMessage;
 import com.withbuddy.chat.entity.ChatMessageDocument;
 import com.withbuddy.chat.entity.MessageType;
@@ -10,6 +11,8 @@ import com.withbuddy.chat.repository.ChatMessageDocumentRepository;
 import com.withbuddy.chat.repository.ChatMessageRepository;
 import com.withbuddy.global.exception.UnauthorizedException;
 import com.withbuddy.global.jwt.JwtService;
+import com.withbuddy.infrastructure.redis.RedisCacheKeys;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.storage.entity.Document;
 import com.withbuddy.storage.entity.DocumentFile;
 import com.withbuddy.storage.repository.DocumentFileRepository;
@@ -32,6 +35,7 @@ public class ChatMessageQueryService {
     private final DocumentRepository documentRepository;
     private final DocumentFileRepository documentFileRepository;
     private final JwtService jwtService;
+    private final RedisCacheService redisCacheService;
 
     public ChatMessageListResponse getMessages(String bearerToken, LocalDate date) {
         String token = jwtService.extractBearerToken(bearerToken);
@@ -208,10 +212,47 @@ public class ChatMessageQueryService {
         );
     }
 
-    private String extractToken(String bearerToken) {
-        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-            throw new UnauthorizedException("Authorization 헤더 형식이 올바르지 않습니다.");
+    public ChatMessageStatusResponse getMessageStatus(String bearerToken, Long questionId) {
+        String token = jwtService.extractBearerToken(bearerToken);
+        Long userId = jwtService.getUserId(token);
+
+        chatMessageRepository.findById(questionId)
+                .filter(message -> userId.equals(message.getUserId()))
+                .orElseThrow(() -> new UnauthorizedException("해당 메시지에 접근 권한이 없습니다."));
+
+        String status = redisCacheService.get(RedisCacheKeys.ragStatus(questionId))
+                .orElse("TIMEOUT");
+
+        if (!"COMPLETED".equals(status)) {
+            return new ChatMessageStatusResponse(status, null);
         }
-        return bearerToken.substring(7);
+
+        Optional<Long> answerId = redisCacheService.get(ragAnswerIdKey(questionId))
+                .map(Long::parseLong);
+        if (answerId.isEmpty()) {
+            return new ChatMessageStatusResponse("COMPLETED", null);
+        }
+
+        Optional<ChatMessage> answer = chatMessageRepository.findById(answerId.get());
+        if (answer.isEmpty()) {
+            return new ChatMessageStatusResponse("COMPLETED", null);
+        }
+
+        List<Long> documentIds = chatMessageDocumentRepository
+                .findByChatMessageIdIn(List.of(answerId.get()))
+                .stream()
+                .map(ChatMessageDocument::getDocumentId)
+                .toList();
+        Map<Long, Document> documentMap = resolveDocumentMap(documentIds);
+        Map<Long, DocumentFile> documentFileMap = resolveDocumentFileMap(documentIds);
+
+        return new ChatMessageStatusResponse(
+                "COMPLETED",
+                toResponse(answer.get(), documentIds, documentMap, documentFileMap)
+        );
+    }
+
+    private static String ragAnswerIdKey(Long questionId) {
+        return "rag:answer:" + questionId;
     }
 }

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -17,6 +17,7 @@ import com.withbuddy.global.jwt.JwtService;
 import com.withbuddy.infrastructure.ai.dto.AiAnswerServerRequest;
 import com.withbuddy.infrastructure.ai.dto.AiAnswerServerResponse;
 import com.withbuddy.infrastructure.ai.dto.AiUserContext;
+import com.withbuddy.infrastructure.ai.exception.AiTimeoutException;
 import com.withbuddy.infrastructure.redis.RedisCacheKeys;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.infrastructure.redis.RedisCacheTtl;
@@ -58,6 +59,7 @@ public class ChatMessageService {
     private final RedisCacheService redisCacheService;
     private final ObjectMapper objectMapper;
     private final TransactionTemplate transactionTemplate;
+    private final AsyncAiCallService asyncAiCallService;
 
     public ChatMessageCreateResponse saveUserMessage(String bearerToken, ChatMessageRequest request) {
         String token = jwtService.extractBearerToken(bearerToken);
@@ -89,9 +91,19 @@ public class ChatMessageService {
                 conversationHistory
         );
 
+        ChatMessageResponse questionResponse = toResponse(
+                savedQuestionMessage,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                Collections.emptyMap()
+        );
+
         AiAnswerServerResponse aiResponse;
         try {
             aiResponse = aiClient.requestAnswer(aiRequest);
+        } catch (AiTimeoutException ex) {
+            asyncAiCallService.callAndSaveAnswer(savedQuestionMessage.getId(), loginUserId, aiRequest);
+            return new ChatMessageCreateResponse(questionResponse, null, "PENDING");
         } catch (RuntimeException ex) {
             redisCacheService.put(
                     RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
@@ -124,18 +136,14 @@ public class ChatMessageService {
         saveConversationPair(loginUserId, savedQuestionMessage.getContent(), savedAnswerMessage.getContent());
 
         return new ChatMessageCreateResponse(
-                toResponse(
-                        savedQuestionMessage,
-                        Collections.emptyList(),
-                        Collections.emptyMap(),
-                        Collections.emptyMap()
-                ),
+                questionResponse,
                 toResponse(
                         savedAnswerMessage,
                         answerDocumentIds,
                         documentMap,
                         documentFileMap
-                )
+                ),
+                "COMPLETED"
         );
     }
 

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -26,6 +26,7 @@ import com.withbuddy.storage.entity.DocumentFile;
 import com.withbuddy.storage.repository.DocumentFileRepository;
 import com.withbuddy.storage.repository.DocumentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -77,6 +78,7 @@ public class ChatMessageService {
                 "PENDING",
                 RedisCacheTtl.RAG_STATUS
         );
+        saveConversationQuestion(loginUserId, savedQuestionMessage.getContent());
 
         AiUserContext userContext = new AiUserContext(
                 loginUserId,
@@ -102,7 +104,16 @@ public class ChatMessageService {
         try {
             aiResponse = aiClient.requestAnswer(aiRequest);
         } catch (AiTimeoutException ex) {
-            asyncAiCallService.callAndSaveAnswer(savedQuestionMessage.getId(), loginUserId, aiRequest);
+            try {
+                asyncAiCallService.callAndSaveAnswer(savedQuestionMessage.getId(), loginUserId, aiRequest);
+            } catch (TaskRejectedException schedulingEx) {
+                redisCacheService.put(
+                        RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
+                        "TIMEOUT",
+                        RedisCacheTtl.RAG_STATUS
+                );
+                return new ChatMessageCreateResponse(questionResponse, null, "TIMEOUT");
+            }
             return new ChatMessageCreateResponse(questionResponse, null, "PENDING");
         } catch (RuntimeException ex) {
             redisCacheService.put(
@@ -133,7 +144,7 @@ public class ChatMessageService {
 
         Map<Long, Document> documentMap = resolveDocumentMap(answerDocumentIds);
         Map<Long, DocumentFile> documentFileMap = resolveDocumentFileMap(answerDocumentIds);
-        saveConversationPair(loginUserId, savedQuestionMessage.getContent(), savedAnswerMessage.getContent());
+        saveConversationAnswer(loginUserId, savedAnswerMessage.getContent());
 
         return new ChatMessageCreateResponse(
                 questionResponse,
@@ -390,13 +401,17 @@ public class ChatMessageService {
         return new ConversationTurn(role, message.getContent());
     }
 
-    private void saveConversationPair(Long userId, String userQuestion, String assistantAnswer) {
+    private void saveConversationQuestion(Long userId, String userQuestion) {
+        saveConversationTurn(userId, new ConversationTurn("user", userQuestion));
+    }
+
+    private void saveConversationAnswer(Long userId, String assistantAnswer) {
+        saveConversationTurn(userId, new ConversationTurn("assistant", assistantAnswer));
+    }
+
+    private void saveConversationTurn(Long userId, ConversationTurn turn) {
         String key = RedisCacheKeys.conversation(String.valueOf(userId));
-        List<ConversationTurn> turns = List.of(
-                new ConversationTurn("user", userQuestion),
-                new ConversationTurn("assistant", assistantAnswer)
-        );
-        writeConversationTurnsWithRecovery(key, turns);
+        writeConversationTurnsWithRecovery(key, List.of(turn));
     }
 
     private void saveConversationHistoryList(Long userId, List<ConversationTurn> history) {

--- a/backend/src/main/java/com/withbuddy/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/withbuddy/global/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.withbuddy.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean("aiCallExecutor")
+    public Executor aiCallExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("ai-async-");
+        executor.setKeepAliveSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AiConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AiConfig.java
@@ -13,7 +13,7 @@ public class AiConfig {
     public RestClient aiRestClient(
             @Value("${ai.server.base-url}") String aiBaseUrl,
             @Value("${ai.server.connect-timeout-ms:5000}") int connectTimeoutMs,
-            @Value("${ai.server.read-timeout-ms:5000}") int readTimeoutMs
+            @Value("${ai.server.read-timeout-ms:10000}") int readTimeoutMs
     ) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(connectTimeoutMs);

--- a/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AsyncAiRestClientConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AsyncAiRestClientConfig.java
@@ -7,21 +7,21 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
-public class AiConfig {
+public class AsyncAiRestClientConfig {
 
-    @Bean
-    public RestClient aiRestClient(
+    @Bean("asyncAiRestClient")
+    public RestClient asyncAiRestClient(
             @Value("${ai.server.base-url}") String aiBaseUrl,
             @Value("${ai.server.connect-timeout-ms:5000}") int connectTimeoutMs,
-            @Value("${ai.server.read-timeout-ms:5000}") int readTimeoutMs
+            @Value("${ai.server.async-read-timeout-ms:55000}") int asyncReadTimeoutMs
     ) {
-        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(connectTimeoutMs);
-        requestFactory.setReadTimeout(readTimeoutMs);
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeoutMs);
+        factory.setReadTimeout(asyncReadTimeoutMs);
 
         return RestClient.builder()
                 .baseUrl(aiBaseUrl)
-                .requestFactory(requestFactory)
+                .requestFactory(factory)
                 .build();
     }
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AsyncAiRestClientConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AsyncAiRestClientConfig.java
@@ -13,7 +13,7 @@ public class AsyncAiRestClientConfig {
     public RestClient asyncAiRestClient(
             @Value("${ai.server.base-url}") String aiBaseUrl,
             @Value("${ai.server.connect-timeout-ms:5000}") int connectTimeoutMs,
-            @Value("${ai.server.async-read-timeout-ms:55000}") int asyncReadTimeoutMs
+            @Value("${ai.server.async-read-timeout-ms:10000}") int asyncReadTimeoutMs
     ) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(connectTimeoutMs);

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -31,7 +31,7 @@ ai:
     base-url: ${AI_SERVER_BASE_URL}
     connect-timeout-ms: ${AI_SERVER_CONNECT_TIMEOUT_MS:5000}
     read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:10000}
-    async-read-timeout-ms: ${AI_SERVER_ASYNC_READ_TIMEOUT_MS:55000}
+    async-read-timeout-ms: ${AI_SERVER_ASYNC_READ_TIMEOUT_MS:10000}
 
 app:
   security:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -30,7 +30,8 @@ ai:
   server:
     base-url: ${AI_SERVER_BASE_URL}
     connect-timeout-ms: ${AI_SERVER_CONNECT_TIMEOUT_MS:5000}
-    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:20000}
+    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:5000}
+    async-read-timeout-ms: ${AI_SERVER_ASYNC_READ_TIMEOUT_MS:55000}
 
 app:
   security:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -30,7 +30,7 @@ ai:
   server:
     base-url: ${AI_SERVER_BASE_URL}
     connect-timeout-ms: ${AI_SERVER_CONNECT_TIMEOUT_MS:5000}
-    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:5000}
+    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:10000}
     async-read-timeout-ms: ${AI_SERVER_ASYNC_READ_TIMEOUT_MS:55000}
 
 app:

--- a/docs/api/api-conversation-history.md
+++ b/docs/api/api-conversation-history.md
@@ -1,0 +1,377 @@
+# BE ↔ AI 서버 대화 이력 전달 API 명세서
+
+> **버전**: v1.2  
+> **작성일**: 2026-04-24  
+> **수정일**: 2026-04-27 — 비동기 AI PENDING 처리, turn 순서 보존, timeout 정책 반영  
+> **대상 엔드포인트**: `POST /internal/ai/answer`  
+> **작성 배경**: AI가 이전 대화를 기억하지 못하는 문제 해결을 위해 BE → AI 서버 요청에 대화 이력을 추가
+
+---
+
+## 1. 변경 요약
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| 요청 필드 | questionId, user, content | questionId, user, content, **conversationHistory** 추가 |
+| 대화 이력 출처 | 없음 | Redis (세션 내) → DB fallback (만료 후) |
+| AI 응답 품질 | 단발성 (맥락 없음) | 이전 대화 참조 가능 |
+| AI 응답 지연 처리 | 요청 스레드가 AI 응답까지 대기 | 10초 초과 시 `PENDING` 반환 후 비동기 처리 |
+| Redis turn 저장 | AI 응답 완료 후 Q&A 페어 저장 | 질문 저장 시 `user` turn 선저장, 답변 완료 시 `assistant` turn 저장 |
+
+---
+
+## 2. 요청 스펙 (Request)
+
+### 엔드포인트
+
+```
+POST /internal/ai/answer
+Content-Type: application/json
+```
+
+### 요청 필드
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `questionId` | Long | Y | 질문 메시지 ID |
+| `user` | AiUserContext | Y | 사용자 정보 |
+| `user.userId` | Long | Y | 사용자 ID |
+| `user.name` | String | Y | 사용자 이름 |
+| `user.companyCode` | String | Y | 회사 코드 |
+| `content` | String | Y | 현재 질문 내용 |
+| `conversationHistory` | ConversationTurn[] | Y | 이전 대화 이력 (없으면 빈 배열 `[]`) |
+| `conversationHistory[].role` | String | Y | `"user"` 또는 `"assistant"` |
+| `conversationHistory[].content` | String | Y | 해당 턴의 메시지 내용 |
+
+### 요청 예시 — 첫 질문 (이력 없음)
+
+```json
+{
+  "questionId": 201,
+  "user": {
+    "userId": 1,
+    "name": "김지원",
+    "companyCode": "WB0001"
+  },
+  "content": "연차는 어떻게 쓰나요?",
+  "conversationHistory": []
+}
+```
+
+### 요청 예시 — 이어지는 질문 (이력 있음)
+
+```json
+{
+  "questionId": 202,
+  "user": {
+    "userId": 1,
+    "name": "김지원",
+    "companyCode": "WB0001"
+  },
+  "content": "그럼 연차 신청은 어디서 해요?",
+  "conversationHistory": [
+    {
+      "role": "user",
+      "content": "연차는 어떻게 쓰나요?"
+    },
+    {
+      "role": "assistant",
+      "content": "연차는 입사 1년 후 15일이 부여되며, 사내 HR 시스템에서 신청할 수 있습니다."
+    }
+  ]
+}
+```
+
+---
+
+## 3. 응답 스펙 (Response)
+
+변경 없음. 현재 스펙 유지.
+
+```json
+{
+  "questionId": 202,
+  "messageType": "rag_answer",
+  "content": "연차 신청은 HR 시스템 > 근태관리 메뉴에서 하실 수 있습니다.",
+  "documents": [
+    { "documentId": 5 }
+  ]
+}
+```
+
+---
+
+## 4. 대화 이력 조회 전략 (BE 내부)
+
+AI 호출 전 `conversationHistory`를 구성하는 우선순위:
+
+```
+1순위: Redis  conversation:{userId}
+   → 세션 내 최근 대화 (TTL 30분)
+   → HIT 시 바로 사용
+
+2순위: DB  chat_messages 테이블
+   → Redis MISS 또는 TTL 만료 시 fallback
+   → userId 기준 최근 10개 메시지 조회
+   → user_question / rag_answer 타입만 필터링
+   → 조회 결과를 Redis에 다시 적재 (TTL 초기화)
+
+이력 없음: conversationHistory = []
+   → 첫 질문이거나 DB에도 기록 없을 때
+```
+
+### 최대 전달 턴 수
+
+| 항목 | 값 |
+|------|-----|
+| 최대 턴 수 | **5턴 (Q&A 10개 메시지)** |
+| 초과 시 처리 | RPUSH + LTRIM으로 Redis 저장 시점에 BE가 직접 제어 |
+| 이유 | AI 서버 토큰 한도 초과 방지, AI 서버에 슬라이딩 로직 의존 금지 |
+
+### Thundering Herd 방지 (DB Fallback 동시 요청)
+
+Redis TTL 만료 직후 다수의 요청이 동시에 DB fallback을 시도하면 `chat_messages` 테이블에 과부하가 발생할 수 있다. 이를 방지하기 위해 DB 조회 전 분산 락을 사용한다.
+
+```
+Redis MISS 발생 시:
+  1. lock:conv:{userId} 분산 락 획득 시도 (TTL 5초)
+  2. 락 획득 성공 → DB 조회 → Redis 적재 → 락 해제
+  3. 락 획득 실패 (다른 요청이 선점) → 짧게 대기 후 Redis 재조회
+     → 이미 적재되어 있으면 HIT 처리
+     → 여전히 MISS면 conversationHistory = [] 로 진행 (graceful degradation)
+```
+
+> 분산 락 구현은 `RedisCacheService.putIfAbsent()`와 Lua 기반 `releaseLock()`을 사용한다.
+
+---
+
+## 5. Redis 저장 포맷 및 turn 순서 정책
+
+### 키
+
+```
+conversation:{userId}       -- 대화 이력 List 자료구조
+lock:conv:{userId}          -- DB fallback 분산 락 (TTL 5초)
+```
+
+### 자료구조 변경
+
+**변경 전** — String (마지막 질문 1개)
+```
+SET conversation:{userId} "연차는 어떻게 쓰나요?"
+```
+
+**변경 후** — Redis List (RPUSH + LTRIM으로 최신 5턴 유지)
+
+```
+-- 질문 메시지 저장 직후
+RPUSH conversation:{userId} '{"role":"user","content":"연차는 어떻게 쓰나요?"}'
+
+-- AI 답변 저장 직후 (동기 완료 또는 비동기 완료)
+RPUSH conversation:{userId} '{"role":"assistant","content":"연차는 입사 1년 후..."}'
+LTRIM conversation:{userId} -10 -1   -- 최신 10개(5턴) 유지, 초과분 자동 제거
+EXPIRE conversation:{userId} 1800    -- TTL 30분 초기화
+```
+
+> Sliding Window 로직은 BE 저장 시점에 `RPUSH + LTRIM`으로 처리한다.  
+> AI 서버에 턴 수 제어를 맡기지 않는다.
+
+### 비동기 완료 시 순서 보존
+
+AI 응답이 10초를 초과하면 API는 즉시 `PENDING`을 반환하고 백그라운드에서 답변 생성을 계속한다. 이때 질문과 답변을 비동기 완료 시점에 함께 append하면 사용자가 대기 중 다른 질문을 보낸 경우 Redis 이력이 다음처럼 뒤섞일 수 있다.
+
+```
+Q2, A2, Q1, A1
+```
+
+이를 방지하기 위해 turn 저장 시점을 분리한다.
+
+```
+1. 질문 DB 저장 직후: user turn append
+2. 동기 AI 완료: assistant turn append
+3. 비동기 AI 완료: assistant turn append
+4. 비동기 스케줄링 실패 또는 AI 실패: assistant turn append 없음, rag 상태만 TIMEOUT 처리
+```
+
+이 정책으로 다음 AI 호출이 읽는 `conversationHistory`의 시간 순서를 안정적으로 유지한다.
+
+### TTL
+
+```
+30분 (기존 유지)
+매 질문/응답 저장 시 EXPIRE로 TTL 초기화
+```
+
+---
+
+## 6. BE 구현 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `infrastructure/ai/dto/ConversationTurn.java` | 신규 record 생성 |
+| `infrastructure/ai/dto/AiAnswerServerRequest.java` | `conversationHistory` 필드 추가 |
+| `chat/service/ChatMessageService.java` | 이력 조회/저장 로직 추가, **트랜잭션 범위 분리** |
+| `chat/dto/ChatMessageCreateResponse.java` | `status` 필드 추가 (`COMPLETED`, `PENDING`, `TIMEOUT`) |
+| `chat/dto/ChatMessageStatusResponse.java` | 비동기 처리 상태 조회 응답 DTO 추가 |
+| `chat/service/AsyncAiCallService.java` | `PENDING` 이후 백그라운드 AI 재호출 |
+| `chat/service/ChatAnswerSaveService.java` | 비동기 답변 저장 및 `assistant` turn append |
+| `global/config/AsyncConfig.java` | AI 비동기 실행용 bounded executor 설정 |
+| `infrastructure/ai/config/AsyncAiRestClientConfig.java` | 비동기 AI RestClient timeout 설정 |
+
+### 채팅 API 응답 상태
+
+`POST /api/v1/chat/messages`는 AI 응답 시간에 따라 다음처럼 응답한다.
+
+```
+10초 내 응답:
+  { question, answer, status: "COMPLETED" }
+
+10초 초과:
+  { question, answer: null, status: "PENDING" }
+
+10초 초과 후 비동기 스케줄링 실패:
+  { question, answer: null, status: "TIMEOUT" }
+```
+
+비동기 처리 상태는 다음 API로 조회한다.
+
+```
+GET /api/v1/chat/messages/{questionId}/status
+```
+
+응답 예시:
+
+```json
+{
+  "status": "COMPLETED",
+  "answer": {
+    "id": 202,
+    "senderType": "BOT",
+    "messageType": "rag_answer",
+    "content": "연차 신청은 HR 시스템 > 근태관리 메뉴에서 하실 수 있습니다."
+  }
+}
+```
+
+### Timeout 정책
+
+| 항목 | 환경변수 | 기본값 | 목적 |
+|------|----------|--------|------|
+| AI connection timeout | `AI_SERVER_CONNECT_TIMEOUT_MS` | `5000` | AI 서버 TCP 연결 대기 |
+| AI 동기 read timeout | `AI_SERVER_READ_TIMEOUT_MS` | `10000` | 사용자 요청을 붙잡는 최대 응답 대기 |
+| AI 비동기 read timeout | `AI_SERVER_ASYNC_READ_TIMEOUT_MS` | `10000` | `PENDING` 이후 백그라운드 AI 응답 대기 |
+
+### 트랜잭션 분리 주의사항
+
+현재 `saveUserMessage()`는 `@Transactional` 안에서 Redis 호출과 AI 서버 HTTP 호출을 함께 수행하고 있다. AI 서버 응답(평균 4.69초) 동안 DB 커넥션이 점유되는 문제가 있으므로, 이력 관련 Redis 로직은 트랜잭션 밖에서 처리한다.
+
+```
+[트랜잭션 밖]  Redis에서 대화 이력 조회 (Redis → DB fallback)
+     ↓
+[트랜잭션 시작]  질문 메시지 DB 저장
+[트랜잭션 종료]
+     ↓
+[트랜잭션 밖]  Redis에 user turn 저장 (RPUSH + LTRIM + EXPIRE)
+     ↓
+[트랜잭션 밖]  AI 서버 호출 (동기 read timeout 기본 10초)
+     ↓
+[트랜잭션 시작]  AI 답변 메시지 DB 저장
+[트랜잭션 종료]
+     ↓
+[트랜잭션 밖]  Redis에 assistant turn 저장 (RPUSH + LTRIM + EXPIRE)
+```
+
+> `@CacheEvict`와 동일한 원칙: Redis 작업은 트랜잭션 완료 후 수행.
+
+---
+
+## 7. AI 서버 구현 변경 범위
+
+> AI 서버 팀 담당
+
+### 요청 스키마 추가
+
+```python
+# schemas/request.py
+class ConversationTurn(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+class AiAnswerServerRequest(BaseModel):
+    question_id: int
+    user: AiUserContext
+    content: str
+    conversation_history: list[ConversationTurn] = []  # 추가
+```
+
+### LangGraph 체인 주입
+
+```python
+from langchain_core.messages import HumanMessage, AIMessage
+
+def to_message_objects(history: list[ConversationTurn]):
+    result = []
+    for turn in history:
+        if turn.role == "user":
+            result.append(HumanMessage(content=turn.content))
+        else:
+            result.append(AIMessage(content=turn.content))
+    return result
+
+chain.invoke({
+    "input": request.content,
+    "chat_history": to_message_objects(request.conversation_history)
+})
+```
+
+### 하위 호환
+
+- `conversation_history`가 `[]`이면 기존 단발성 RAG와 동일하게 동작
+- 필드 자체가 없을 경우에도 기본값 `[]`로 처리
+
+---
+
+## 8. 작업 순서
+
+```
+Step 1. 이 명세서 기준으로 BE / AI 서버팀 스펙 합의
+Step 2. [AI 서버] conversation_history 수신 + LangGraph 주입 구현
+Step 3. [BE] ConversationTurn DTO + ChatMessageService 이력 로직 구현
+         - Redis 조회 → MISS 시 DB fallback → 이력 구성
+         - AI 응답 후 Redis 업데이트
+Step 4. [통합 테스트] 대화 연속성 end-to-end 확인
+```
+
+> Step 2, 3은 병렬 진행 가능. 각자 mock으로 독립 테스트 후 Step 4에서 통합.
+
+---
+
+## 9. 별도 이슈 (이번 작업 범위 외)
+
+이번 구현에서 다루지 않지만 후속 작업으로 등록이 필요한 항목:
+
+| 항목 | 내용 |
+|------|------|
+| SSE 세션 cleanup | 서버 재기동 시 해당 `instanceId`의 `sse:session:*` 키 일괄 삭제 |
+| Presigned URL 실패 대응 | URL 생성 실패 시 캐싱하지 않고 즉시 에러 반환 |
+| KEYS → SCAN 전환 | `deleteByPrefix()` 내 `redisTemplate.keys()` 사용 여부 점검 및 SCAN으로 교체 |
+| 직렬화 최적화 | Jackson JSON → MessagePack/Protobuf (메모리 20~30% 절감, 여유 시 검토) |
+| Caffeine L1 캐시 | `quicktap:{day}` 등 불변 데이터 애플리케이션 메모리 캐싱 (Redis 트래픽 감소) |
+
+---
+
+## 10. 테스트 시나리오
+
+| 케이스 | 조건 | 기대 동작 |
+|--------|------|-----------|
+| 첫 질문 | Redis MISS, DB 기록 없음 | `conversationHistory: []` 전송 |
+| 세션 내 연속 질문 | Redis HIT | Redis List에서 이력 조회 후 전송 |
+| 세션 만료 후 재질문 | Redis MISS, DB 기록 있음 | 분산 락 획득 → DB 최근 10개 조회 → Redis 재적재 → 전송 |
+| 오래된 대화 참조 | "저번에 복지카드 얘기했는데" | DB fallback으로 이력 복원하여 AI가 맥락 파악 |
+| 동시 DB fallback | Redis MISS 상태에서 요청 다수 | 락 선점 1개만 DB 조회, 나머지는 Redis 재조회 또는 `[]`로 graceful 처리 |
+| 6턴 이상 누적 | RPUSH 후 List 길이 > 10 | LTRIM -10 -1 으로 자동 제거, 5턴만 유지 |
+| AI 동기 응답 성공 | 10초 내 AI 응답 | `status=COMPLETED`, user turn 저장 후 assistant turn 저장 |
+| AI 동기 timeout | 10초 초과 | `status=PENDING`, user turn은 이미 저장, 비동기 처리 시작 |
+| 비동기 AI 완료 | `PENDING` 이후 AI 응답 성공 | BOT 답변 저장, assistant turn만 append, `rag:answer:{questionId}` 저장, `status=COMPLETED` |
+| 비동기 스케줄링 실패 | executor 포화 등 `TaskRejectedException` | `status=TIMEOUT`, assistant turn 저장 안 함 |
+| AI 응답 실패 | timeout 등 | assistant turn 저장 안 함, 기존 이력 보존 |


### PR DESCRIPTION
## Summary
- main 기준 release 브랜치에서 비동기 AI PENDING 처리 관련 커밋만 cherry-pick했습니다.
- 포함 커밋:
  - feat: AI 답변 지연 시 비동기 처리와 상태 조회 추가
  - fix: AI 동기 read timeout 기본값을 10초로 조정
  - fix: AI 비동기 read timeout 기본값을 10초로 조정
  - fix: 비동기 AI 응답의 대화 이력 순서 보존
  - docs: conversationHistory 비동기 처리 정책 반영

## Verification
- cd backend && ./gradlew.bat compileJava