### PR TITLE
fix(auth): JWT 파싱 예외를 인증 실패로 표준화

### DIFF
--- a/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageStatusResponse.java
+++ b/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageStatusResponse.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ChatMessageStatusResponse {
-    private String status;              // PENDING, COMPLETED, TIMEOUT
+    private String status;              // PENDING, COMPLETED, TIMEOUT, UNKNOWN
     private ChatMessageResponse answer; // COMPLETED일 때만 값이 있음, 나머지는 null
 }

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageQueryService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageQueryService.java
@@ -217,22 +217,24 @@ public class ChatMessageQueryService {
                 .filter(message -> userId.equals(message.getUserId()))
                 .orElseThrow(() -> new UnauthorizedException("해당 메시지에 접근 권한이 없습니다."));
 
-        String status = redisCacheService.get(RedisCacheKeys.ragStatus(questionId))
-                .orElse("TIMEOUT");
+        Optional<String> status = redisCacheService.get(RedisCacheKeys.ragStatus(questionId));
+        if (status.isEmpty()) {
+            return new ChatMessageStatusResponse("UNKNOWN", null);
+        }
 
-        if (!"COMPLETED".equals(status)) {
-            return new ChatMessageStatusResponse(status, null);
+        if (!"COMPLETED".equals(status.get())) {
+            return new ChatMessageStatusResponse(status.get(), null);
         }
 
         Optional<Long> answerId = redisCacheService.get(ragAnswerIdKey(questionId))
                 .map(Long::parseLong);
         if (answerId.isEmpty()) {
-            return new ChatMessageStatusResponse("COMPLETED", null);
+            return new ChatMessageStatusResponse("UNKNOWN", null);
         }
 
         Optional<ChatMessage> answer = chatMessageRepository.findById(answerId.get());
         if (answer.isEmpty()) {
-            return new ChatMessageStatusResponse("COMPLETED", null);
+            return new ChatMessageStatusResponse("UNKNOWN", null);
         }
 
         List<Long> documentIds = chatMessageDocumentRepository

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -127,12 +127,6 @@ public class ChatMessageService {
         if (!savedQuestionMessage.getId().equals(aiResponse.getQuestionId())) {
             throw new IllegalStateException("AI 응답의 questionId가 저장된 질문 ID와 일치하지 않습니다.");
         }
-        redisCacheService.put(
-                RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
-                "COMPLETED",
-                RedisCacheTtl.RAG_STATUS
-        );
-
         MessageType answerMessageType = aiResponse.getMessageType();
         List<Long> answerDocumentIds = filterExistingDocumentIds(extractDocumentIds(aiResponse));
         ChatMessage savedAnswerMessage = transactionTemplate.execute(
@@ -145,6 +139,16 @@ public class ChatMessageService {
         Map<Long, Document> documentMap = resolveDocumentMap(answerDocumentIds);
         Map<Long, DocumentFile> documentFileMap = resolveDocumentFileMap(answerDocumentIds);
         saveConversationAnswer(loginUserId, savedAnswerMessage.getContent());
+        redisCacheService.put(
+                ragAnswerIdKey(savedQuestionMessage.getId()),
+                String.valueOf(savedAnswerMessage.getId()),
+                RedisCacheTtl.RAG_STATUS
+        );
+        redisCacheService.put(
+                RedisCacheKeys.ragStatus(savedQuestionMessage.getId()),
+                "COMPLETED",
+                RedisCacheTtl.RAG_STATUS
+        );
 
         return new ChatMessageCreateResponse(
                 questionResponse,
@@ -156,6 +160,10 @@ public class ChatMessageService {
                 ),
                 "COMPLETED"
         );
+    }
+
+    private static String ragAnswerIdKey(Long questionId) {
+        return "rag:answer:" + questionId;
     }
 
     private List<ConversationTurn> sanitizeConversationHistoryForAi(List<ConversationTurn> history) {


### PR DESCRIPTION
-  parseValidClaims 예외 처리 보강  - 비정상 예외를 UnauthorizedException으로 변환해 500 방지

