### PR TITLE
feat: RMQ nudge/analytics 파이프라인 도입 (MVP: DLX/DLQ 제외)

### DIFF
--- a/backend/src/main/java/com/withbuddy/activity/log/RedisActivityLogService.java
+++ b/backend/src/main/java/com/withbuddy/activity/log/RedisActivityLogService.java
@@ -1,0 +1,43 @@
+package com.withbuddy.activity.log;
+
+import com.withbuddy.activity.entity.EventTarget;
+import com.withbuddy.activity.entity.EventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisActivityLogService {
+
+    private static final String ACTIVITY_LOG_KEY = "log:activity:events";
+    private static final Duration ACTIVITY_LOG_TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void append(Long userId, EventType eventType, EventTarget eventTarget) {
+        String target = eventTarget != null ? eventTarget.name() : "UNKNOWN";
+        String payload = String.format(
+                "{\"userId\":%d,\"eventType\":\"%s\",\"eventTarget\":\"%s\",\"loggedAt\":\"%s\"}",
+                userId,
+                eventType.name(),
+                target,
+                OffsetDateTime.now(ZoneOffset.UTC)
+        );
+        try {
+            redisTemplate.opsForList().leftPush(ACTIVITY_LOG_KEY, payload);
+            redisTemplate.opsForList().trim(ACTIVITY_LOG_KEY, 0, 999);
+            redisTemplate.expire(ACTIVITY_LOG_KEY, ACTIVITY_LOG_TTL);
+        } catch (RuntimeException ex) {
+            log.warn("[ACTIVITY] Redis log append failed. userId={}, eventType={}, eventTarget={}",
+                    userId, eventType, target, ex);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/activity/log/RmqActivityLogService.java
+++ b/backend/src/main/java/com/withbuddy/activity/log/RmqActivityLogService.java
@@ -1,0 +1,36 @@
+package com.withbuddy.activity.log;
+
+import com.withbuddy.activity.entity.EventTarget;
+import com.withbuddy.activity.entity.EventType;
+import com.withbuddy.infrastructure.mq.AnalyticsEventPublisher;
+import com.withbuddy.infrastructure.mq.event.AnalyticsEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RmqActivityLogService {
+
+    private final AnalyticsEventPublisher analyticsEventPublisher;
+
+    public void publish(Long userId, EventType eventType, EventTarget eventTarget) {
+        AnalyticsEvent event = new AnalyticsEvent(
+                UUID.randomUUID().toString(),
+                userId,
+                eventType.name(),
+                eventTarget != null ? eventTarget.name() : "UNKNOWN",
+                System.currentTimeMillis()
+        );
+        try {
+            analyticsEventPublisher.publish(event);
+        } catch (RuntimeException ex) {
+            log.warn("[ANALYTICS] RMQ publish failed. userId={}, eventType={}, eventTarget={}",
+                    userId, eventType, eventTarget, ex);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/auth/service/AuthService.java
+++ b/backend/src/main/java/com/withbuddy/auth/service/AuthService.java
@@ -1,6 +1,10 @@
 package com.withbuddy.auth.service;
 
 import com.withbuddy.activity.service.UserActivityLogService;
+import com.withbuddy.activity.log.RedisActivityLogService;
+import com.withbuddy.activity.log.RmqActivityLogService;
+import com.withbuddy.activity.entity.EventTarget;
+import com.withbuddy.activity.entity.EventType;
 import com.withbuddy.auth.dto.request.LoginRequest;
 import com.withbuddy.auth.dto.response.LoginResponse;
 import com.withbuddy.auth.dto.response.LoginUserResponse;
@@ -26,6 +30,8 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtService jwtService;
     private final UserActivityLogService userActivityLogService;
+    private final RedisActivityLogService redisActivityLogService;
+    private final RmqActivityLogService rmqActivityLogService;
     private final RedisCacheService redisCacheService;
     private final ObjectMapper objectMapper;
 
@@ -57,6 +63,8 @@ public class AuthService {
         );
 
         userActivityLogService.saveLoginSessionStart(user.getId());
+        redisActivityLogService.append(user.getId(), EventType.SESSION_START, EventTarget.LOGIN);
+        rmqActivityLogService.publish(user.getId(), EventType.SESSION_START, EventTarget.LOGIN);
 
         LoginUserResponse userResponse = new LoginUserResponse(
                 user.getId(),

--- a/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/withbuddy/chat/controller/ChatMessageController.java
@@ -1,6 +1,10 @@
 package com.withbuddy.chat.controller;
 
 import com.withbuddy.activity.dto.LogResponse;
+import com.withbuddy.activity.entity.EventTarget;
+import com.withbuddy.activity.entity.EventType;
+import com.withbuddy.activity.log.RedisActivityLogService;
+import com.withbuddy.activity.log.RmqActivityLogService;
 import com.withbuddy.activity.service.UserActivityLogService;
 import com.withbuddy.chat.dto.ChatMessageCreateResponse;
 import com.withbuddy.chat.dto.ChatMessageListResponse;
@@ -8,6 +12,7 @@ import com.withbuddy.chat.dto.ChatMessageRequest;
 import com.withbuddy.chat.dto.ChatMessageStatusResponse;
 import com.withbuddy.chat.service.ChatMessageQueryService;
 import com.withbuddy.chat.service.ChatMessageService;
+import com.withbuddy.global.jwt.JwtService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +34,9 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
     private final ChatMessageQueryService chatMessageQueryService;
     private final UserActivityLogService userActivityLogService;
+    private final JwtService jwtService;
+    private final RedisActivityLogService redisActivityLogService;
+    private final RmqActivityLogService rmqActivityLogService;
 
     @PostMapping("/messages")
     @ResponseStatus(HttpStatus.CREATED)
@@ -54,6 +62,11 @@ public class ChatMessageController {
             @RequestHeader(value = "Authorization", required = false) String bearerToken
     ) {
         LogResponse response = userActivityLogService.saveChatSessionStart(bearerToken);
+        if (response.isLogged()) {
+            Long userId = extractUserId(bearerToken);
+            redisActivityLogService.append(userId, EventType.SESSION_START, EventTarget.CHAT);
+            rmqActivityLogService.publish(userId, EventType.SESSION_START, EventTarget.CHAT);
+        }
 
         if (response.isLogged()) {
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -75,7 +88,11 @@ public class ChatMessageController {
     public LogResponse saveQuickQuestionClick(
             @RequestHeader(value = "Authorization", required = false) String bearerToken
     ) {
-        return userActivityLogService.saveQuickQuestionClick(bearerToken);
+        LogResponse response = userActivityLogService.saveQuickQuestionClick(bearerToken);
+        Long userId = extractUserId(bearerToken);
+        redisActivityLogService.append(userId, EventType.BUTTON_CLICK, EventTarget.QUICK_TAP);
+        rmqActivityLogService.publish(userId, EventType.BUTTON_CLICK, EventTarget.QUICK_TAP);
+        return response;
     }
 
     @GetMapping("/messages/{questionId}/status")
@@ -85,5 +102,10 @@ public class ChatMessageController {
             @PathVariable Long questionId
     ) {
         return chatMessageQueryService.getMessageStatus(bearerToken, questionId);
+    }
+
+    private Long extractUserId(String bearerToken) {
+        String token = jwtService.extractBearerToken(bearerToken);
+        return jwtService.getUserId(token);
     }
 }

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -476,6 +476,12 @@ public class ChatMessageService {
         chatMessageRepository.save(message);
     }
 
+    @Transactional
+    public void saveNudgeMessage(Long userId, String content) {
+        ChatMessage message = ChatMessage.createSuggestionMessage(userId, null, content);
+        chatMessageRepository.save(message);
+    }
+
     private List<ChatMessageResponse.RecommendedContactResponse> resolveRecommendedContacts(ChatMessage message) {
         if (message.getSenderType() != SenderType.BOT || message.getMessageType() != MessageType.no_result) {
             return List.of();

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -477,7 +477,11 @@ public class ChatMessageService {
     }
 
     @Transactional
-    public void saveNudgeMessage(Long userId, String content) {
+    public void saveNudgeMessage(Long userId, Long suggestionId, String content) {
+        if (suggestionId != null) {
+            saveSuggestionMessageIfNotExists(userId, suggestionId, content);
+            return;
+        }
         ChatMessage message = ChatMessage.createSuggestionMessage(userId, null, content);
         chatMessageRepository.save(message);
     }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/AnalyticsEventPublisher.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/AnalyticsEventPublisher.java
@@ -1,0 +1,33 @@
+package com.withbuddy.infrastructure.mq;
+
+import com.withbuddy.infrastructure.mq.event.AnalyticsEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AnalyticsEventPublisher {
+
+    private static final String ANALYTICS_ROUTING_KEY = "analytics.behavior";
+
+    private final RabbitTemplate rabbitTemplate;
+    private final AppRabbitMqProperties properties;
+    private final MessagingMetricsService metricsService;
+
+    public void publish(AnalyticsEvent event) {
+        long start = System.currentTimeMillis();
+        try {
+            rabbitTemplate.convertAndSend(
+                    properties.exchange(),
+                    ANALYTICS_ROUTING_KEY,
+                    event
+            );
+            metricsService.recordPublishLatency(System.currentTimeMillis() - start);
+        } catch (RuntimeException ex) {
+            metricsService.incrementPublishFailure();
+            throw ex;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/AppRabbitMqProperties.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/AppRabbitMqProperties.java
@@ -5,13 +5,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "app.rabbitmq")
 public record AppRabbitMqProperties(
         String exchange,
-        String dlxExchange,
         String queueReport,
         String queueNudge,
         String queueAnalytics,
-        String queueDlq,
-        String queueDlqNudge,
-        String queueDlqAnalytics,
-        Integer nudgeTtlMs
+        Integer nudgeTtlMs,
+        Integer analyticsTtlMs,
+        Integer listenerPrefetch,
+        Integer listenerMaxAttempts
 ) {
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingController.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingController.java
@@ -1,11 +1,15 @@
 package com.withbuddy.infrastructure.mq;
 
+import com.withbuddy.global.jwt.JwtService;
 import com.withbuddy.infrastructure.mq.event.NudgeEvent;
 import com.withbuddy.infrastructure.mq.event.NudgeType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +24,10 @@ public class MessagingController {
 
     private final MessagingQueueStatusService messagingQueueStatusService;
     private final NudgeEventPublisher nudgeEventPublisher;
+    private final JwtService jwtService;
+
+    @Value("${app.rabbitmq.test-endpoint-enabled:false}")
+    private boolean testEndpointEnabled;
 
     @GetMapping("/queue/status")
     public ResponseEntity<Map<String, Object>> getQueueStatus() {
@@ -28,9 +36,20 @@ public class MessagingController {
 
     @PostMapping("/nudge/test")
     public ResponseEntity<Void> publishTestNudge(
+            @RequestHeader("Authorization") String bearerToken,
             @RequestParam Long userId,
             @RequestParam(defaultValue = "false") boolean forceError
     ) {
+        if (!testEndpointEnabled) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        String token = jwtService.extractBearerToken(bearerToken);
+        Long requesterUserId = jwtService.getUserId(token);
+        if (!requesterUserId.equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         if (!forceError && userId <= 0) {
             return ResponseEntity.badRequest().build();
         }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingController.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingController.java
@@ -1,0 +1,45 @@
+package com.withbuddy.infrastructure.mq;
+
+import com.withbuddy.infrastructure.mq.event.NudgeEvent;
+import com.withbuddy.infrastructure.mq.event.NudgeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/messaging")
+public class MessagingController {
+
+    private final MessagingQueueStatusService messagingQueueStatusService;
+    private final NudgeEventPublisher nudgeEventPublisher;
+
+    @GetMapping("/queue/status")
+    public ResponseEntity<Map<String, Object>> getQueueStatus() {
+        return ResponseEntity.ok(messagingQueueStatusService.getStatus());
+    }
+
+    @PostMapping("/nudge/test")
+    public ResponseEntity<Void> publishTestNudge(
+            @RequestParam(defaultValue = "false") boolean forceError
+    ) {
+        NudgeEvent event = new NudgeEvent(
+                UUID.randomUUID().toString(),
+                -1L,
+                forceError ? "__FORCE_ERROR__" : "[TEST] withbuddy nudge pipeline check",
+                null,
+                NudgeType.GENERAL,
+                System.currentTimeMillis()
+        );
+        nudgeEventPublisher.publish(event);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingController.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingController.java
@@ -28,11 +28,17 @@ public class MessagingController {
 
     @PostMapping("/nudge/test")
     public ResponseEntity<Void> publishTestNudge(
+            @RequestParam Long userId,
             @RequestParam(defaultValue = "false") boolean forceError
     ) {
+        if (!forceError && userId <= 0) {
+            return ResponseEntity.badRequest().build();
+        }
+
         NudgeEvent event = new NudgeEvent(
                 UUID.randomUUID().toString(),
-                -1L,
+                userId,
+                null,
                 forceError ? "__FORCE_ERROR__" : "[TEST] withbuddy nudge pipeline check",
                 null,
                 NudgeType.GENERAL,

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingMetricsService.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingMetricsService.java
@@ -1,0 +1,82 @@
+package com.withbuddy.infrastructure.mq;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MessagingMetricsService {
+
+    private static final String PUBLISH_LATENCY_KEY = "metrics:publish:latency";
+    private static final String QUEUE_LATENCY_KEY = "metrics:queue:latency";
+    private static final String E2E_LATENCY_KEY = "metrics:e2e:latency";
+    private static final String PUBLISH_FAILURE_KEY = "metrics:publish:failure";
+    private static final String SUCCESS_COUNT_KEY = "metrics:success:count";
+    private static final Duration METRIC_TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void recordPublishLatency(long latencyMs) {
+        pushLatency(PUBLISH_LATENCY_KEY, latencyMs);
+    }
+
+    public void recordQueueLatency(long latencyMs) {
+        pushLatency(QUEUE_LATENCY_KEY, latencyMs);
+    }
+
+    public void recordEndToEndLatency(long latencyMs) {
+        pushLatency(E2E_LATENCY_KEY, latencyMs);
+    }
+
+    public void incrementPublishFailure() {
+        redisTemplate.opsForValue().increment(PUBLISH_FAILURE_KEY);
+        redisTemplate.expire(PUBLISH_FAILURE_KEY, METRIC_TTL);
+    }
+
+    public void incrementSuccessCount() {
+        redisTemplate.opsForValue().increment(SUCCESS_COUNT_KEY);
+        redisTemplate.expire(SUCCESS_COUNT_KEY, METRIC_TTL);
+    }
+
+    public Map<String, Object> snapshot() {
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        metrics.put("publishLatencyAvgMs", calcAvg(PUBLISH_LATENCY_KEY));
+        metrics.put("queueLatencyAvgMs", calcAvg(QUEUE_LATENCY_KEY));
+        metrics.put("e2eLatencyAvgMs", calcAvg(E2E_LATENCY_KEY));
+        metrics.put("publishFailureCount", readLong(PUBLISH_FAILURE_KEY));
+        metrics.put("successCount", readLong(SUCCESS_COUNT_KEY));
+        return metrics;
+    }
+
+    private void pushLatency(String key, long latencyMs) {
+        redisTemplate.opsForList().leftPush(key, String.valueOf(latencyMs));
+        redisTemplate.opsForList().trim(key, 0, 99);
+        redisTemplate.expire(key, METRIC_TTL);
+    }
+
+    private double calcAvg(String key) {
+        List<String> values = redisTemplate.opsForList().range(key, 0, 99);
+        if (values == null || values.isEmpty()) {
+            return 0.0;
+        }
+        return values.stream()
+                .mapToLong(Long::parseLong)
+                .average()
+                .orElse(0.0);
+    }
+
+    private long readLong(String key) {
+        String value = redisTemplate.opsForValue().get(key);
+        if (value == null || value.isBlank()) {
+            return 0L;
+        }
+        return Long.parseLong(value);
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingQueueStatusService.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/MessagingQueueStatusService.java
@@ -1,0 +1,50 @@
+package com.withbuddy.infrastructure.mq;
+
+import com.rabbitmq.client.AMQP;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessagingQueueStatusService {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final AppRabbitMqProperties properties;
+    private final MessagingMetricsService metricsService;
+
+    public Map<String, Object> getStatus() {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("exchange", properties.exchange());
+        response.put("queues", Map.of(
+                properties.queueNudge(), queueSnapshot(properties.queueNudge()),
+                properties.queueAnalytics(), queueSnapshot(properties.queueAnalytics())
+        ));
+        response.put("metrics", metricsService.snapshot());
+        return response;
+    }
+
+    private Map<String, Object> queueSnapshot(String queueName) {
+        Map<String, Object> queue = new LinkedHashMap<>();
+        queue.put("name", queueName);
+        try {
+            AMQP.Queue.DeclareOk declareOk = rabbitTemplate.execute(channel -> channel.queueDeclarePassive(queueName));
+            if (declareOk == null) {
+                queue.put("readyMessages", 0);
+                queue.put("consumers", 0);
+            } else {
+                queue.put("readyMessages", declareOk.getMessageCount());
+                queue.put("consumers", declareOk.getConsumerCount());
+            }
+        } catch (Exception ex) {
+            log.warn("[RMQ] queue status unavailable: {}", queueName, ex);
+            queue.put("error", ex.getMessage());
+        }
+        return queue;
+    }
+}

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/NudgeEventPublisher.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/NudgeEventPublisher.java
@@ -1,0 +1,33 @@
+package com.withbuddy.infrastructure.mq;
+
+import com.withbuddy.infrastructure.mq.event.NudgeEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NudgeEventPublisher {
+
+    private static final String NUDGE_ROUTING_KEY = "nudge.trigger";
+
+    private final RabbitTemplate rabbitTemplate;
+    private final AppRabbitMqProperties properties;
+    private final MessagingMetricsService metricsService;
+
+    public void publish(NudgeEvent event) {
+        long start = System.currentTimeMillis();
+        try {
+            rabbitTemplate.convertAndSend(
+                    properties.exchange(),
+                    NUDGE_ROUTING_KEY,
+                    event
+            );
+            metricsService.recordPublishLatency(System.currentTimeMillis() - start);
+        } catch (RuntimeException ex) {
+            metricsService.incrementPublishFailure();
+            throw ex;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
@@ -1,19 +1,29 @@
 package com.withbuddy.infrastructure.mq;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Declarables;
-import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 
 @Configuration
+@EnableRabbit
+@Slf4j
 @EnableConfigurationProperties(AppRabbitMqProperties.class)
 public class RabbitMqConfig {
 
@@ -23,23 +33,13 @@ public class RabbitMqConfig {
     }
 
     @Bean
-    public DirectExchange deadLetterExchange(AppRabbitMqProperties properties) {
-        return new DirectExchange(properties.dlxExchange(), true, false);
-    }
-
-    @Bean
     public Queue reportQueue(AppRabbitMqProperties properties) {
-        return QueueBuilder.durable(properties.queueReport())
-                .withArgument("x-dead-letter-exchange", properties.dlxExchange())
-                .withArgument("x-dead-letter-routing-key", properties.queueDlq())
-                .build();
+        return QueueBuilder.durable(properties.queueReport()).build();
     }
 
     @Bean
     public Queue nudgeQueue(AppRabbitMqProperties properties) {
         return QueueBuilder.durable(properties.queueNudge())
-                .withArgument("x-dead-letter-exchange", properties.dlxExchange())
-                .withArgument("x-dead-letter-routing-key", properties.queueDlqNudge())
                 .withArgument("x-message-ttl", properties.nudgeTtlMs())
                 .build();
     }
@@ -47,36 +47,16 @@ public class RabbitMqConfig {
     @Bean
     public Queue analyticsQueue(AppRabbitMqProperties properties) {
         return QueueBuilder.durable(properties.queueAnalytics())
-                .withArgument("x-dead-letter-exchange", properties.dlxExchange())
-                .withArgument("x-dead-letter-routing-key", properties.queueDlqAnalytics())
+                .withArgument("x-message-ttl", intOrDefault(properties.analyticsTtlMs(), 30000))
                 .build();
-    }
-
-    @Bean
-    public Queue deadLetterReportQueue(AppRabbitMqProperties properties) {
-        return new Queue(properties.queueDlq(), true);
-    }
-
-    @Bean
-    public Queue deadLetterNudgeQueue(AppRabbitMqProperties properties) {
-        return new Queue(properties.queueDlqNudge(), true);
-    }
-
-    @Bean
-    public Queue deadLetterAnalyticsQueue(AppRabbitMqProperties properties) {
-        return new Queue(properties.queueDlqAnalytics(), true);
     }
 
     @Bean
     public Declarables appBindings(
             TopicExchange appExchange,
-            DirectExchange deadLetterExchange,
             Queue reportQueue,
             Queue nudgeQueue,
             Queue analyticsQueue,
-            Queue deadLetterReportQueue,
-            Queue deadLetterNudgeQueue,
-            Queue deadLetterAnalyticsQueue,
             AppRabbitMqProperties properties
     ) {
         Binding reportBinding = BindingBuilder
@@ -92,31 +72,62 @@ public class RabbitMqConfig {
                 .to(appExchange)
                 .with("analytics.#");
 
-        Binding reportDlqBinding = BindingBuilder
-                .bind(deadLetterReportQueue)
-                .to(deadLetterExchange)
-                .with(properties.queueDlq());
-        Binding nudgeDlqBinding = BindingBuilder
-                .bind(deadLetterNudgeQueue)
-                .to(deadLetterExchange)
-                .with(properties.queueDlqNudge());
-        Binding analyticsDlqBinding = BindingBuilder
-                .bind(deadLetterAnalyticsQueue)
-                .to(deadLetterExchange)
-                .with(properties.queueDlqAnalytics());
-
         return new Declarables(
                 reportBinding,
                 nudgeBinding,
-                analyticsBinding,
-                reportDlqBinding,
-                nudgeDlqBinding,
-                analyticsDlqBinding
+                analyticsBinding
         );
     }
 
     @Bean
     public MessageConverter messageConverter() {
         return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(messageConverter);
+        template.setMandatory(true);
+        template.setConfirmCallback((correlationData, ack, cause) -> {
+            if (!ack) {
+                log.error("[RMQ] publish confirm failed. cause={}, correlationData={}", cause, correlationData);
+            }
+        });
+        template.setReturnsCallback(returned -> log.error(
+                "[RMQ] unroutable message. exchange={}, routingKey={}, replyCode={}, replyText={}",
+                returned.getExchange(),
+                returned.getRoutingKey(),
+                returned.getReplyCode(),
+                returned.getReplyText()
+        ));
+        return template;
+    }
+
+    @Bean
+    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+            ConnectionFactory connectionFactory,
+            MessageConverter messageConverter,
+            AppRabbitMqProperties properties
+    ) {
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(messageConverter);
+        factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+        factory.setDefaultRequeueRejected(false);
+        factory.setPrefetchCount(intOrDefault(properties.listenerPrefetch(), 10));
+        factory.setAdviceChain(retryInterceptor(properties));
+        return factory;
+    }
+
+    private RetryOperationsInterceptor retryInterceptor(AppRabbitMqProperties properties) {
+        return RetryInterceptorBuilder.stateless()
+                .maxAttempts(intOrDefault(properties.listenerMaxAttempts(), 3))
+                .recoverer(new RejectAndDontRequeueRecoverer())
+                .build();
+    }
+
+    private int intOrDefault(Integer value, int fallback) {
+        return value != null ? value : fallback;
     }
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/AnalyticsConsumer.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/AnalyticsConsumer.java
@@ -57,11 +57,7 @@ public class AnalyticsConsumer {
                     event.eventId(), event.userId(), event.action());
         } catch (Exception ex) {
             log.error("[ANALYTICS] processing failed. deliveryTag={}", deliveryTag, ex);
-            try {
-                channel.basicNack(deliveryTag, false, false);
-            } catch (Exception nackEx) {
-                log.error("[ANALYTICS] nack failed. deliveryTag={}", deliveryTag, nackEx);
-            }
+            throw new IllegalStateException("[ANALYTICS] processing failed", ex);
         }
     }
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/AnalyticsConsumer.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/AnalyticsConsumer.java
@@ -1,0 +1,68 @@
+package com.withbuddy.infrastructure.mq.consumer;
+
+import com.rabbitmq.client.Channel;
+import com.withbuddy.infrastructure.mq.MessagingMetricsService;
+import com.withbuddy.infrastructure.mq.entity.MessagingEventLog;
+import com.withbuddy.infrastructure.mq.entity.MessagingEventType;
+import com.withbuddy.infrastructure.mq.event.AnalyticsEvent;
+import com.withbuddy.infrastructure.mq.repository.MessagingEventLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AnalyticsConsumer {
+
+    private final MessagingEventLogRepository eventLogRepository;
+    private final MessagingMetricsService metricsService;
+
+    @RabbitListener(queues = "${app.rabbitmq.queue-analytics}", containerFactory = "rabbitListenerContainerFactory")
+    public void handleAnalytics(
+            @Payload AnalyticsEvent event,
+            Channel channel,
+            @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag
+    ) {
+        try {
+            if (event == null || !StringUtils.hasText(event.eventId())) {
+                channel.basicAck(deliveryTag, false);
+                return;
+            }
+
+            if (!eventLogRepository.existsByEventId(event.eventId())) {
+                eventLogRepository.save(new MessagingEventLog(
+                        event.eventId(),
+                        MessagingEventType.ANALYTICS,
+                        LocalDateTime.now()
+                ));
+            }
+
+            if (event.publishedAt() > 0L) {
+                long latency = Math.max(0L, System.currentTimeMillis() - event.publishedAt());
+                metricsService.recordQueueLatency(latency);
+                metricsService.recordEndToEndLatency(latency);
+            }
+            metricsService.incrementSuccessCount();
+
+            channel.basicAck(deliveryTag, false);
+            log.debug("[ANALYTICS] processed. eventId={}, userId={}, action={}",
+                    event.eventId(), event.userId(), event.action());
+        } catch (Exception ex) {
+            log.error("[ANALYTICS] processing failed. deliveryTag={}", deliveryTag, ex);
+            try {
+                channel.basicNack(deliveryTag, false, false);
+            } catch (Exception nackEx) {
+                log.error("[ANALYTICS] nack failed. deliveryTag={}", deliveryTag, nackEx);
+            }
+        }
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/NudgeConsumer.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/NudgeConsumer.java
@@ -39,6 +39,7 @@ public class NudgeConsumer {
             Channel channel,
             @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag
     ) {
+        String idempotencyKey = null;
         try {
             if (event == null || !StringUtils.hasText(event.eventId())) {
                 log.warn("[NUDGE] invalid payload. messageId={}", message.getMessageProperties().getMessageId());
@@ -50,7 +51,7 @@ public class NudgeConsumer {
                 throw new IllegalStateException("[TEST] forced nudge consumer error");
             }
 
-            String idempotencyKey = RedisCacheKeys.nudgeIdempotency(event.eventId());
+            idempotencyKey = RedisCacheKeys.nudgeIdempotency(event.eventId());
             boolean isNew = redisCacheService.putIfAbsent(
                     idempotencyKey,
                     "1",
@@ -66,7 +67,7 @@ public class NudgeConsumer {
                 return;
             }
 
-            chatMessageService.saveNudgeMessage(event.userId(), event.message());
+            chatMessageService.saveNudgeMessage(event.userId(), event.suggestionId(), event.message());
             eventLogRepository.save(new MessagingEventLog(
                     event.eventId(),
                     MessagingEventType.NUDGE,
@@ -83,12 +84,12 @@ public class NudgeConsumer {
             channel.basicAck(deliveryTag, false);
             log.info("[NUDGE] processed. eventId={}, userId={}", event.eventId(), event.userId());
         } catch (Exception ex) {
-            log.error("[NUDGE] processing failed. deliveryTag={}", deliveryTag, ex);
-            try {
-                channel.basicNack(deliveryTag, false, false);
-            } catch (Exception nackEx) {
-                log.error("[NUDGE] nack failed. deliveryTag={}", deliveryTag, nackEx);
+            if (StringUtils.hasText(idempotencyKey)) {
+                // Retry 전파 시 idempotency 키로 인해 재처리가 막히지 않도록 복구한다.
+                redisCacheService.delete(idempotencyKey);
             }
+            log.error("[NUDGE] processing failed. deliveryTag={}", deliveryTag, ex);
+            throw new IllegalStateException("[NUDGE] processing failed", ex);
         }
     }
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/NudgeConsumer.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/NudgeConsumer.java
@@ -1,0 +1,95 @@
+package com.withbuddy.infrastructure.mq.consumer;
+
+import com.rabbitmq.client.Channel;
+import com.withbuddy.chat.service.ChatMessageService;
+import com.withbuddy.infrastructure.mq.MessagingMetricsService;
+import com.withbuddy.infrastructure.mq.entity.MessagingEventLog;
+import com.withbuddy.infrastructure.mq.entity.MessagingEventType;
+import com.withbuddy.infrastructure.mq.event.NudgeEvent;
+import com.withbuddy.infrastructure.redis.RedisCacheKeys;
+import com.withbuddy.infrastructure.redis.RedisCacheService;
+import com.withbuddy.infrastructure.redis.RedisCacheTtl;
+import com.withbuddy.infrastructure.mq.repository.MessagingEventLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NudgeConsumer {
+
+    private final ChatMessageService chatMessageService;
+    private final RedisCacheService redisCacheService;
+    private final MessagingEventLogRepository eventLogRepository;
+    private final MessagingMetricsService metricsService;
+
+    @RabbitListener(queues = "${app.rabbitmq.queue-nudge}", containerFactory = "rabbitListenerContainerFactory")
+    public void handleNudge(
+            @Payload NudgeEvent event,
+            Message message,
+            Channel channel,
+            @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag
+    ) {
+        try {
+            if (event == null || !StringUtils.hasText(event.eventId())) {
+                log.warn("[NUDGE] invalid payload. messageId={}", message.getMessageProperties().getMessageId());
+                channel.basicAck(deliveryTag, false);
+                return;
+            }
+
+            if ("__FORCE_ERROR__".equals(event.message())) {
+                throw new IllegalStateException("[TEST] forced nudge consumer error");
+            }
+
+            String idempotencyKey = RedisCacheKeys.nudgeIdempotency(event.eventId());
+            boolean isNew = redisCacheService.putIfAbsent(
+                    idempotencyKey,
+                    "1",
+                    RedisCacheTtl.NUDGE_IDEMPOTENCY
+            );
+            if (!isNew) {
+                channel.basicAck(deliveryTag, false);
+                return;
+            }
+
+            if (eventLogRepository.existsByEventId(event.eventId())) {
+                channel.basicAck(deliveryTag, false);
+                return;
+            }
+
+            chatMessageService.saveNudgeMessage(event.userId(), event.message());
+            eventLogRepository.save(new MessagingEventLog(
+                    event.eventId(),
+                    MessagingEventType.NUDGE,
+                    LocalDateTime.now()
+            ));
+
+            if (event.publishedAt() > 0L) {
+                long latency = Math.max(0L, System.currentTimeMillis() - event.publishedAt());
+                metricsService.recordQueueLatency(latency);
+                metricsService.recordEndToEndLatency(latency);
+            }
+            metricsService.incrementSuccessCount();
+
+            channel.basicAck(deliveryTag, false);
+            log.info("[NUDGE] processed. eventId={}, userId={}", event.eventId(), event.userId());
+        } catch (Exception ex) {
+            log.error("[NUDGE] processing failed. deliveryTag={}", deliveryTag, ex);
+            try {
+                channel.basicNack(deliveryTag, false, false);
+            } catch (Exception nackEx) {
+                log.error("[NUDGE] nack failed. deliveryTag={}", deliveryTag, nackEx);
+            }
+        }
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/entity/MessagingEventLog.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/entity/MessagingEventLog.java
@@ -1,0 +1,43 @@
+package com.withbuddy.infrastructure.mq.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "messaging_event_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessagingEventLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, length = 120, unique = true)
+    private String eventId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    private MessagingEventType eventType;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public MessagingEventLog(String eventId, MessagingEventType eventType, LocalDateTime createdAt) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.createdAt = createdAt;
+    }
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/entity/MessagingEventType.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/entity/MessagingEventType.java
@@ -1,0 +1,7 @@
+package com.withbuddy.infrastructure.mq.entity;
+
+public enum MessagingEventType {
+    NUDGE,
+    ANALYTICS
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/event/AnalyticsEvent.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/event/AnalyticsEvent.java
@@ -1,0 +1,11 @@
+package com.withbuddy.infrastructure.mq.event;
+
+public record AnalyticsEvent(
+        String eventId,
+        Long userId,
+        String action,
+        String target,
+        long publishedAt
+) {
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/event/NudgeEvent.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/event/NudgeEvent.java
@@ -1,0 +1,12 @@
+package com.withbuddy.infrastructure.mq.event;
+
+public record NudgeEvent(
+        String eventId,
+        Long userId,
+        String message,
+        String fileId,
+        NudgeType type,
+        long publishedAt
+) {
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/event/NudgeEvent.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/event/NudgeEvent.java
@@ -3,6 +3,7 @@ package com.withbuddy.infrastructure.mq.event;
 public record NudgeEvent(
         String eventId,
         Long userId,
+        Long suggestionId,
         String message,
         String fileId,
         NudgeType type,

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/event/NudgeType.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/event/NudgeType.java
@@ -1,0 +1,9 @@
+package com.withbuddy.infrastructure.mq.event;
+
+public enum NudgeType {
+    GENERAL,
+    FILE,
+    RAG_RESULT,
+    SYSTEM_ALERT
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/repository/MessagingEventLogRepository.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/repository/MessagingEventLogRepository.java
@@ -1,0 +1,10 @@
+package com.withbuddy.infrastructure.mq.repository;
+
+import com.withbuddy.infrastructure.mq.entity.MessagingEventLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessagingEventLogRepository extends JpaRepository<MessagingEventLog, Long> {
+
+    boolean existsByEventId(String eventId);
+}
+

--- a/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheKeys.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheKeys.java
@@ -33,6 +33,10 @@ public final class RedisCacheKeys {
         return "nudge:sent:" + userId + ":" + day;
     }
 
+    public static String nudgeIdempotency(String eventId) {
+        return "idempotency:nudge:" + eventId;
+    }
+
     public static String conversation(String sessionId) {
         return "conversation:" + sessionId;
     }

--- a/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheTtl.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheTtl.java
@@ -13,6 +13,7 @@ public final class RedisCacheTtl {
     public static final Duration SSE_MISSED = Duration.ofMinutes(5);
     public static final Duration RAG_STATUS = Duration.ofMinutes(5);
     public static final Duration NUDGE_SENT = Duration.ofHours(48);
+    public static final Duration NUDGE_IDEMPOTENCY = Duration.ofMinutes(10);
     public static final Duration CONVERSATION = Duration.ofMinutes(30);
     public static final Duration PRESIGNED_URL = Duration.ofMinutes(10);
     public static final Duration DOCS_LIST_FIRST = Duration.ofMinutes(5);

--- a/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
+++ b/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
@@ -2,6 +2,9 @@ package com.withbuddy.onboarding.service;
 
 import com.withbuddy.auth.repository.UserRepository;
 import com.withbuddy.chat.service.ChatMessageService;
+import com.withbuddy.infrastructure.mq.NudgeEventPublisher;
+import com.withbuddy.infrastructure.mq.event.NudgeEvent;
+import com.withbuddy.infrastructure.mq.event.NudgeType;
 import com.withbuddy.infrastructure.redis.RedisCacheKeys;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.infrastructure.redis.RedisCacheTtl;
@@ -11,15 +14,18 @@ import com.withbuddy.onboarding.entity.OnboardingSuggestion;
 import com.withbuddy.onboarding.repository.OnboardingSuggestionRepository;
 import com.withbuddy.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class OnboardingSuggestionService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -28,6 +34,7 @@ public class OnboardingSuggestionService {
     private final OnboardingSuggestionRepository onboardingSuggestionRepository;
     private final ChatMessageService chatMessageService;
     private final RedisCacheService redisCacheService;
+    private final NudgeEventPublisher nudgeEventPublisher;
 
     public OnboardingSuggestionListResponse getMyOnboardingSuggestions(Long userId) {
         User user = userRepository.findById(userId)
@@ -52,11 +59,24 @@ public class OnboardingSuggestionService {
 
         String nudgeSentKey = RedisCacheKeys.nudgeSent(userId, dayOffset);
         if (redisCacheService.putIfAbsent(nudgeSentKey, "1", RedisCacheTtl.NUDGE_SENT)) {
-            chatMessageService.saveSuggestionMessageIfNotExists(
+            NudgeEvent nudgeEvent = new NudgeEvent(
+                    UUID.randomUUID().toString(),
                     userId,
-                    suggestion.getId(),
-                    content
+                    content,
+                    null,
+                    NudgeType.GENERAL,
+                    System.currentTimeMillis()
             );
+            try {
+                nudgeEventPublisher.publish(nudgeEvent);
+            } catch (RuntimeException ex) {
+                log.warn("[NUDGE] publish failed. fallback to direct save. userId={}, dayOffset={}", userId, dayOffset, ex);
+                chatMessageService.saveSuggestionMessageIfNotExists(
+                        userId,
+                        suggestion.getId(),
+                        content
+                );
+            }
         }
 
         OnboardingSuggestionItemResponse response = new OnboardingSuggestionItemResponse(

--- a/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
+++ b/backend/src/main/java/com/withbuddy/onboarding/service/OnboardingSuggestionService.java
@@ -62,6 +62,7 @@ public class OnboardingSuggestionService {
             NudgeEvent nudgeEvent = new NudgeEvent(
                     UUID.randomUUID().toString(),
                     userId,
+                    suggestion.getId(),
                     content,
                     null,
                     NudgeType.GENERAL,

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -43,15 +43,14 @@ app:
           global-access: ${STORAGE_API_GLOBAL_ACCESS:true}
           active: ${STORAGE_API_KEY_ACTIVE:true}
   rabbitmq:
-    exchange: ${RABBITMQ_EXCHANGE:withbuddy.exchange}
-    dlx-exchange: ${RABBITMQ_DLX_EXCHANGE:withbuddy.dlx}
+    exchange: ${RABBITMQ_EXCHANGE:withbuddy.events}
     queue-report: ${RABBITMQ_QUEUE_REPORT:withbuddy.report}
     queue-nudge: ${RABBITMQ_QUEUE_NUDGE:q.nudge}
     queue-analytics: ${RABBITMQ_QUEUE_ANALYTICS:q.analytics}
-    queue-dlq: ${RABBITMQ_QUEUE_DLQ:withbuddy.report.dlq}
-    queue-dlq-nudge: ${RABBITMQ_QUEUE_DLQ_NUDGE:q.dlq.nudge}
-    queue-dlq-analytics: ${RABBITMQ_QUEUE_DLQ_ANALYTICS:q.dlq.analytics}
     nudge-ttl-ms: ${RABBITMQ_NUDGE_TTL_MS:86400000}
+    analytics-ttl-ms: ${RABBITMQ_ANALYTICS_TTL_MS:30000}
+    listener-prefetch: ${RABBITMQ_LISTENER_PREFETCH:10}
+    listener-max-attempts: ${RABBITMQ_LISTENER_MAX_ATTEMPTS:3}
   storage:
     provider: ${STORAGE_PROVIDER:local}
     local-base-dir: ${STORAGE_LOCAL_BASE_DIR:storage-data}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -44,6 +44,7 @@ app:
           active: ${STORAGE_API_KEY_ACTIVE:true}
   rabbitmq:
     exchange: ${RABBITMQ_EXCHANGE:withbuddy.events}
+    test-endpoint-enabled: ${RABBITMQ_TEST_ENDPOINT_ENABLED:false}
     queue-report: ${RABBITMQ_QUEUE_REPORT:withbuddy.report}
     queue-nudge: ${RABBITMQ_QUEUE_NUDGE:q.nudge}
     queue-analytics: ${RABBITMQ_QUEUE_ANALYTICS:q.analytics}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -61,15 +61,14 @@ app:
           global-access: ${STORAGE_API_GLOBAL_ACCESS:true}
           active: ${STORAGE_API_KEY_ACTIVE:true}
   rabbitmq:
-    exchange: ${RABBITMQ_EXCHANGE:withbuddy.exchange}
-    dlx-exchange: ${RABBITMQ_DLX_EXCHANGE:withbuddy.dlx}
+    exchange: ${RABBITMQ_EXCHANGE:withbuddy.events}
     queue-report: ${RABBITMQ_QUEUE_REPORT:withbuddy.report}
     queue-nudge: ${RABBITMQ_QUEUE_NUDGE:q.nudge}
     queue-analytics: ${RABBITMQ_QUEUE_ANALYTICS:q.analytics}
-    queue-dlq: ${RABBITMQ_QUEUE_DLQ:withbuddy.report.dlq}
-    queue-dlq-nudge: ${RABBITMQ_QUEUE_DLQ_NUDGE:q.dlq.nudge}
-    queue-dlq-analytics: ${RABBITMQ_QUEUE_DLQ_ANALYTICS:q.dlq.analytics}
     nudge-ttl-ms: ${RABBITMQ_NUDGE_TTL_MS:86400000}
+    analytics-ttl-ms: ${RABBITMQ_ANALYTICS_TTL_MS:30000}
+    listener-prefetch: ${RABBITMQ_LISTENER_PREFETCH:10}
+    listener-max-attempts: ${RABBITMQ_LISTENER_MAX_ATTEMPTS:3}
   storage:
     provider: ${STORAGE_PROVIDER:local}
     local-base-dir: ${STORAGE_LOCAL_BASE_DIR:storage-data}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -62,6 +62,7 @@ app:
           active: ${STORAGE_API_KEY_ACTIVE:true}
   rabbitmq:
     exchange: ${RABBITMQ_EXCHANGE:withbuddy.events}
+    test-endpoint-enabled: ${RABBITMQ_TEST_ENDPOINT_ENABLED:false}
     queue-report: ${RABBITMQ_QUEUE_REPORT:withbuddy.report}
     queue-nudge: ${RABBITMQ_QUEUE_NUDGE:q.nudge}
     queue-analytics: ${RABBITMQ_QUEUE_ANALYTICS:q.analytics}

--- a/backend/src/main/resources/db/migration/V12__create_messaging_event_logs.sql
+++ b/backend/src/main/resources/db/migration/V12__create_messaging_event_logs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS messaging_event_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id VARCHAR(120) NOT NULL,
+    event_type VARCHAR(30) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT pk_messaging_event_logs PRIMARY KEY (id),
+    CONSTRAINT uk_messaging_event_logs_event_id UNIQUE (event_id)
+);
+


### PR DESCRIPTION
## 요약
- RMQ 기반 Nudge/Analytics 파이프라인 도입
- 활동 로그 Redis+RMQ 이중 기록 경로 추가
- 메시징 상태/메트릭 API 추가 (`/api/v1/messaging/*`)
- MVP 범위로 DLX/DLQ 설정 제거

## 포함 범위
- develop에서 머지된 #459의 2개 커밋만 main 기준으로 이식
- `origin/main` 대비 변경 파일 수: 26

## 리뷰 반영
- consumer 예외 전파로 retry 정책 동작 복구
- `/api/v1/messaging/nudge/test`에 유효 `userId` 입력 반영
- nudge 이벤트에 `suggestionId` 포함 및 dedupe 경로 보존

## 참고
- develop 반영 PR: https://github.com/WithBuddyAi/withbuddy/pull/459 (merged)

## 검증
- `./gradlew.bat compileJava` 통과
