### PR TITLE
feat(ai): BE Internal API 연동 - cache/task/callback 구현

### DIFF
--- a/ai/chains/rag_chain.py
+++ b/ai/chains/rag_chain.py
@@ -171,14 +171,19 @@ def _extract_contact_from_docs(docs: List[Document]) -> str | None:
             return m.group(1).strip()
     return None
 
-async def _fire_unanswered_alert(user_id: str, question: str) -> None:
-    """미답변 저장 + Slack 알림 (백그라운드)"""
+async def _fire_unanswered_alert(user_id: str, question: str, company_code: str = "") -> None:
+    """미답변 저장 + Slack 알림 + nudge Task 등록 (백그라운드)"""
     try:
         from tasks.slack_notifier import notify_unanswered_question
         qid = add_unanswered(user_id, question)
         await notify_unanswered_question(user_id, question, qid)
     except Exception:
-        pass  # 알림 실패가 채팅 응답에 영향주지 않도록
+        pass
+    try:
+        from core.be_client import enqueue_nudge
+        enqueue_nudge(user_id, company_code, question, str(qid))
+    except Exception:
+        pass
 
 _COMPANY_NAMES: dict[str, str] = {
     "WB0001": "테크 주식회사",
@@ -607,7 +612,7 @@ async def stream_rag_chain(user_id: str, question: str, user_name: str = "", com
             contact_msg = f"\n\n이 부분은 **{hr_team}**에 직접 여쭤보시면 가장 정확한 답을 얻으실 수 있어요!"
         yield contact_msg, None, None
         fixed += contact_msg
-        asyncio.create_task(_fire_unanswered_alert(user_id, question))
+        asyncio.create_task(_fire_unanswered_alert(user_id, question, company_code))
 
     save_interaction(user_id, question, fixed)
     related_docs = find_related_docs(question)

--- a/ai/core/be_client.py
+++ b/ai/core/be_client.py
@@ -1,0 +1,231 @@
+"""
+BE Internal API 클라이언트
+────────────────────────────────────────────
+Redis/RabbitMQ를 BE HTTP API를 통해 간접 사용합니다.
+AI 서버는 REDIS_URL, RABBITMQ_URL을 직접 사용하지 않습니다.
+
+환경변수:
+  BACKEND_INTERNAL_URL  BE 내부 서버 주소 (예: http://10.0.0.81:8080)
+  INTERNAL_API_KEY      X-API-Key 공유 시크릿
+  AI_CALLBACK_URL       AI 서버 콜백 수신 주소 (예: https://ai.itsdev.kr)
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+import time
+import uuid
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_BACKEND_URL = os.getenv("BACKEND_INTERNAL_URL", "http://10.0.0.81:8080")
+_API_KEY = os.getenv("INTERNAL_API_KEY", "")
+_AI_CALLBACK_URL = os.getenv("AI_CALLBACK_URL", "https://ai.itsdev.kr")
+
+
+def _headers() -> dict:
+    return {
+        "Content-Type": "application/json",
+        "X-API-Key": _API_KEY,
+        "X-Request-Id": str(uuid.uuid4()),
+    }
+
+
+def _call(method: str, path: str, *, json_body=None, timeout: float = 2.0, max_retries: int = 1):
+    """공통 HTTP 요청 헬퍼.
+    - 429: retryAfterSeconds 대기 후 1회 재시도
+    - 에러: RFC 9457 detail 필드 파싱해서 로깅
+    """
+    url = f"{_BACKEND_URL}{path}"
+    for attempt in range(max_retries + 1):
+        r = requests.request(method, url, headers=_headers(), json=json_body, timeout=timeout)
+
+        if r.status_code == 429 and attempt < max_retries:
+            try:
+                retry_after = r.json().get("retryAfterSeconds", 1)
+            except Exception:
+                retry_after = 1
+            logger.warning("BE API 429 Rate Limit [%s %s] — %s초 후 재시도", method, path, retry_after)
+            time.sleep(retry_after)
+            continue
+
+        if not r.ok:
+            try:
+                err = r.json()
+                logger.warning(
+                    "BE API 오류 [%s %s] %s (%s): %s",
+                    method, path,
+                    err.get("title", r.status_code),
+                    r.status_code,
+                    err.get("detail", ""),
+                )
+            except Exception:
+                logger.warning("BE API 오류 [%s %s] status=%s", method, path, r.status_code)
+
+        r.raise_for_status()
+        return r
+
+    return None
+
+
+# ── Cache API ────────────────────────────────────────────────
+
+def cache_get(namespace: str, key: str):
+    """캐시 단일 조회. 없으면 None 반환."""
+    try:
+        r = _call("POST", "/internal/v1/cache/get",
+                  json_body={"namespace": namespace, "key": key, "defaultValue": None})
+        data = r.json()
+        return data.get("value") if data.get("found") else None
+    except Exception as e:
+        logger.warning("cache_get 실패 (%s:%s): %s", namespace, key, e)
+        return None
+
+
+def cache_get_multi(namespace: str, keys: list) -> dict:
+    """캐시 다중 조회. {key: value} 형태로 반환 (found인 것만 포함)."""
+    try:
+        r = _call("POST", "/internal/v1/cache/get-multi",
+                  json_body={"namespace": namespace, "keys": keys})
+        items = r.json().get("items", [])
+        return {item["key"]: item["value"] for item in items if item.get("found")}
+    except Exception as e:
+        logger.warning("cache_get_multi 실패 (%s): %s", namespace, e)
+        return {}
+
+
+def cache_set(namespace: str, key: str, value, ttl_seconds: int = 300) -> bool:
+    """캐시 단일 저장. 실패 시 False 반환."""
+    try:
+        _call("POST", "/internal/v1/cache/set",
+              json_body={"namespace": namespace, "key": key, "value": value, "ttlSeconds": ttl_seconds})
+        return True
+    except Exception as e:
+        logger.warning("cache_set 실패 (%s:%s): %s", namespace, key, e)
+        return False
+
+
+def cache_set_multi(namespace: str, items: list[dict], ttl_seconds: int = 300) -> dict:
+    """캐시 다중 저장. items: [{"key": ..., "value": ...}, ...]
+    비원자적 — 부분 실패 가능.
+    반환: {"ok": bool, "written": int, "errors": [...]}
+    """
+    try:
+        payload = [{"key": i["key"], "value": i["value"], "ttlSeconds": ttl_seconds} for i in items]
+        r = _call("POST", "/internal/v1/cache/set-multi",
+                  json_body={"namespace": namespace, "items": payload})
+        data = r.json()
+        if not data.get("ok") and data.get("errors"):
+            for err in data["errors"]:
+                logger.warning("cache_set_multi 부분 실패 key=%s: %s", err.get("key"), err.get("detail"))
+        return data
+    except Exception as e:
+        logger.warning("cache_set_multi 실패 (%s): %s", namespace, e)
+        return {"ok": False, "written": 0, "errors": []}
+
+
+def cache_del(namespace: str, key: str) -> bool:
+    """캐시 삭제."""
+    try:
+        _call("POST", "/internal/v1/cache/del",
+              json_body={"namespace": namespace, "key": key})
+        return True
+    except Exception as e:
+        logger.warning("cache_del 실패 (%s:%s): %s", namespace, key, e)
+        return False
+
+
+# ── Task API (RabbitMQ 추상화) ───────────────────────────────
+
+def enqueue_nudge(user_id: str, company_code: str, question: str, question_id: str) -> dict | None:
+    """미답변 질문 nudge Task를 BE RMQ에 등록."""
+    try:
+        r = _call("POST", "/internal/v1/tasks",
+                  json_body={
+                      "type": "ai.nudge.analysis",
+                      "payload": {
+                          "userId": user_id,
+                          "companyCode": company_code,
+                          "question": question,
+                          "questionId": question_id,
+                      },
+                      "priority": "normal",
+                      "idempotencyKey": f"nudge-{question_id}-v1",
+                      "timeoutSeconds": 600,
+                      "retryCount": 3,
+                      "callbackUrl": f"{_AI_CALLBACK_URL}/internal/ai/callback",
+                  },
+                  timeout=3.0,
+                  max_retries=1)
+        return r.json()
+    except Exception as e:
+        logger.warning("enqueue_nudge 실패 (user=%s): %s", user_id, e)
+        return None
+
+
+def get_task_status(task_id: str) -> dict | None:
+    """Task 상태 조회."""
+    try:
+        r = _call("GET", f"/internal/v1/tasks/{task_id}")
+        return r.json()
+    except Exception as e:
+        logger.warning("get_task_status 실패 (taskId=%s): %s", task_id, e)
+        return None
+
+
+def get_task_result(task_id: str) -> dict | None:
+    """Task 결과 조회. TTL 만료(24h) 후 404 반환됨."""
+    try:
+        r = _call("GET", f"/internal/v1/tasks/{task_id}/result")
+        return r.json()
+    except Exception as e:
+        logger.warning("get_task_result 실패 (taskId=%s): %s", task_id, e)
+        return None
+
+
+def cancel_task(task_id: str) -> dict | None:
+    """Task 취소. SUCCESS/FAILED/TIMED_OUT/CANCELLED 상태에서 호출 시 409."""
+    try:
+        r = _call("DELETE", f"/internal/v1/tasks/{task_id}")
+        return r.json()
+    except Exception as e:
+        logger.warning("cancel_task 실패 (taskId=%s): %s", task_id, e)
+        return None
+
+
+def retry_task(task_id: str, reason: str = "manual-retry") -> dict | None:
+    """Task 재시도. RUNNING 상태 재시도 시 409, SUCCESS 재시도 시 새 taskId 발급."""
+    try:
+        r = _call("POST", f"/internal/v1/tasks/{task_id}/retry",
+                  json_body={"reason": reason})
+        return r.json()
+    except Exception as e:
+        logger.warning("retry_task 실패 (taskId=%s): %s", task_id, e)
+        return None
+
+
+# ── Callback 검증 ────────────────────────────────────────────
+
+def verify_callback_signature(body: bytes, signature: str, timestamp: str, request_id: str) -> bool:
+    """BE 콜백 HMAC-SHA256 서명 검증.
+    1. X-Callback-Timestamp ±300초 확인
+    2. Canonical String 재조합 → HMAC-SHA256 비교
+    """
+    secret = _API_KEY
+    if not secret:
+        return False
+
+    try:
+        ts = int(timestamp)
+        if abs(time.time() - ts) > 300:
+            logger.warning("Callback timestamp 만료: %s", timestamp)
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    canonical = f"{timestamp}\n{request_id}\n{body.decode()}"
+    expected = "sha256=" + hmac.new(secret.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)

--- a/ai/main.py
+++ b/ai/main.py
@@ -23,7 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from routers import admin, chat, docs, knowledge, leader, mybuddy, preboarding, profile, recommend, report, slack
+from routers import admin, callback, chat, docs, knowledge, leader, mybuddy, preboarding, profile, recommend, report, slack
 from tasks.scheduler import start_scheduler, stop_scheduler
 
 # .env 파일에서 환경변수 로드 (ANTHROPIC_API_KEY, SLACK_BOT_TOKEN 등)
@@ -85,6 +85,7 @@ app.add_middleware(
 # ── 라우터 등록 ──────────────────────────────
 
 app.include_router(admin.router)
+app.include_router(callback.router)
 app.include_router(chat.router)
 app.include_router(report.router)
 app.include_router(recommend.router)

--- a/ai/memory/chat_history.py
+++ b/ai/memory/chat_history.py
@@ -1,62 +1,51 @@
 """
 대화 히스토리 관리 모듈
 ────────────────────────────────────────────
-사용자별 멀티턴 대화를 관리합니다.
-JSON 파일로 영속화하여 서버 재시작 후에도 이전 대화가 유지됩니다.
-data/history/{user_id}.json 에 저장됩니다.
+BE Internal Cache API를 통해 Redis에 영속화합니다.
+로컬 인메모리 캐시로 BE 요청을 최소화합니다.
 """
 
-import json
-from pathlib import Path
 from typing import Dict, List
 
 from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_core.messages import BaseMessage
 
-# 히스토리 저장 디렉토리
-_HISTORY_DIR = Path(__file__).parent.parent / "data" / "history"
-_HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+from core.be_client import cache_del, cache_get, cache_set
 
-# 인메모리 캐시: 파일을 매번 읽지 않기 위해 한 번 로드 후 캐시
-_memory_store: Dict[str, InMemoryChatMessageHistory] = {}
+_MAX_TURNS = 5
+_TTL = 86400  # 24시간
 
-_MAX_TURNS = 5  # 최대 유지 대화 쌍 수
+_local: Dict[str, InMemoryChatMessageHistory] = {}
 
 
-def _history_path(user_id: str) -> Path:
-    return _HISTORY_DIR / f"{user_id}.json"
+def _cache_key(user_id: str) -> str:
+    return f"history:{user_id}"
 
 
-def _load_from_file(user_id: str) -> InMemoryChatMessageHistory:
+def _load(user_id: str) -> InMemoryChatMessageHistory:
     mem = InMemoryChatMessageHistory()
-    path = _history_path(user_id)
-    if path.exists():
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            for item in data:
-                if item.get("role") == "human":
-                    mem.add_user_message(item["content"])
-                elif item.get("role") == "ai":
-                    mem.add_ai_message(item["content"])
-        except Exception:
-            pass
+    data = cache_get("chat", _cache_key(user_id))
+    if data and isinstance(data, list):
+        for item in data:
+            if item.get("role") == "human":
+                mem.add_user_message(item["content"])
+            elif item.get("role") == "ai":
+                mem.add_ai_message(item["content"])
     return mem
 
 
-def _save_to_file(user_id: str, mem: InMemoryChatMessageHistory) -> None:
+def _persist(user_id: str, mem: InMemoryChatMessageHistory) -> None:
     data = [
         {"role": "human" if msg.type == "human" else "ai", "content": msg.content}
         for msg in mem.messages
     ]
-    _history_path(user_id).write_text(
-        json.dumps(data, ensure_ascii=False), encoding="utf-8"
-    )
+    cache_set("chat", _cache_key(user_id), data, _TTL)
 
 
 def get_memory(user_id: str) -> InMemoryChatMessageHistory:
-    if user_id not in _memory_store:
-        _memory_store[user_id] = _load_from_file(user_id)
-    return _memory_store[user_id]
+    if user_id not in _local:
+        _local[user_id] = _load(user_id)
+    return _local[user_id]
 
 
 def get_chat_history(user_id: str) -> List[BaseMessage]:
@@ -68,20 +57,16 @@ def save_interaction(user_id: str, human_message: str, ai_message: str) -> None:
     mem.add_user_message(human_message)
     mem.add_ai_message(ai_message)
 
-    # 오래된 메시지 정리
     max_messages = _MAX_TURNS * 2
     if len(mem.messages) > max_messages:
         mem.messages = mem.messages[-max_messages:]
 
-    _save_to_file(user_id, mem)
+    _persist(user_id, mem)
 
 
 def clear_memory(user_id: str) -> None:
-    if user_id in _memory_store:
-        _memory_store[user_id].clear()
-    path = _history_path(user_id)
-    if path.exists():
-        path.unlink()
+    _local.pop(user_id, None)
+    cache_del("chat", _cache_key(user_id))
 
 
 def get_history_as_text(user_id: str) -> str:

--- a/ai/routers/callback.py
+++ b/ai/routers/callback.py
@@ -1,0 +1,55 @@
+"""
+BE Task 콜백 수신 엔드포인트
+────────────────────────────────────────────
+BE가 Task 완료 시 AI로 콜백을 전송합니다.
+HMAC-SHA256 서명 검증 후 이벤트를 처리합니다.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+
+from core.be_client import cache_get, cache_set, verify_callback_signature
+
+router = APIRouter(prefix="/internal/ai", tags=["internal-callback"])
+logger = logging.getLogger(__name__)
+
+
+@router.post("/callback")
+async def receive_callback(request: Request):
+    """BE Task 완료 콜백 수신"""
+    body = await request.body()
+    signature = request.headers.get("X-Callback-Signature", "")
+    timestamp = request.headers.get("X-Callback-Timestamp", "")
+    request_id = request.headers.get("X-Request-Id", "")
+
+    # Nonce 중복 확인 (600초 TTL)
+    nonce_key = f"nonce:{request_id}"
+    if cache_get("callback", nonce_key) is not None:
+        return {"ok": True}
+
+    # HMAC 검증
+    if not verify_callback_signature(body, signature, timestamp, request_id):
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    # Nonce 저장
+    cache_set("callback", nonce_key, 1, ttl_seconds=600)
+
+    # 이벤트 처리
+    try:
+        event = json.loads(body)
+        event_type = event.get("event")
+        task_id = event.get("taskId")
+        status = event.get("status")
+
+        logger.info("Callback: event=%s taskId=%s status=%s", event_type, task_id, status)
+
+        # 이벤트 타입별 처리 (필요 시 확장)
+        if event_type == "TASK_COMPLETED" and status == "SUCCESS":
+            pass  # 추후 필요한 처리 추가
+
+    except Exception as e:
+        logger.error("Callback 처리 오류: %s", e)
+
+    return {"ok": True}


### PR DESCRIPTION
## 추가 요약
- BE Internal API v1.1 명세 기준 AI 쪽 구현
- core/be_client.py: cache/task API 클라이언트 (429 재시도, RFC 9457 오류 파싱)
- memory/chat_history.py: 로컬 인메모리 → BE cache API (Redis 영속화)
- routers/callback.py: BE Task 콜백 수신 엔드포인트 (HMAC-SHA256 검증)
- chains/rag_chain.py: nudge enqueue 시 company_code 추가
- main.py: callback 라우터 등록


- BE INTERNAL_API_KEY 환경변수 세팅 필요 
