### PR TITLE
fix(rabbitmq): avoid fatal startup on auth failure

### DIFF
--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
@@ -126,6 +126,7 @@ public class RabbitMqConfig {
         factory.setMessageConverter(messageConverter);
         factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
         factory.setDefaultRequeueRejected(false);
+        factory.setContainerCustomizer(container -> container.setPossibleAuthenticationFailureFatal(false));
         factory.setPrefetchCount(intOrDefault(properties.listenerPrefetch(), 10));
         factory.setAdviceChain(retryInterceptor(properties));
         return factory;


### PR DESCRIPTION
## Summary
- set Rabbit listener container to not treat authentication failure as fatal at startup
- allow backend to stay up for HTTP health even when RabbitMQ auth is temporarily misconfigured

## Why
- current deploy fails health check because Spring context shuts down when Rabbit consumer startup fails with ACCESS_REFUSED
- Redis/DB path is healthy; this change isolates MQ startup failure from full app startup

## Verification
- ./gradlew.bat compileJava