### PR TITLE
Reapply "fix(storage): allow global storage API key downloads"

### DIFF
--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -469,7 +469,9 @@ public class DocumentStorageService {
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서를 찾을 수 없습니다."));
 
         validateCompanyBoundary(requesterScope, document.getCompanyCode());
-        validateTemplateDocument(document);
+        if (!requesterScope.globalAccess()) {
+            validateTemplateDocument(document);
+        }
 
         DocumentFile file = documentFileRepository.findByDocumentId(document.getId())
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서 파일 메타데이터를 찾을 수 없습니다."));
@@ -477,11 +479,9 @@ public class DocumentStorageService {
         StorageSource source = resolveSource(file);
         int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
         String redisKey = RedisCacheKeys.presignedUrl(file.getId(), source.name());
-
         String downloadUrl = redisCacheService.get(redisKey)
                 .filter(StringUtils::hasText)
                 .orElseGet(() -> createAndCacheDownloadUrl(documentId, file, source, redisKey, preauthTtlSeconds));
-
         return new DocumentDownloadResponse(downloadUrl, preauthTtlSeconds, source.name());
     }
 
@@ -529,7 +529,9 @@ public class DocumentStorageService {
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서를 찾을 수 없습니다."));
 
         validateCompanyBoundary(requesterScope, document.getCompanyCode());
-        validateTemplateDocument(document);
+        if (!requesterScope.globalAccess()) {
+            validateTemplateDocument(document);
+        }
 
         DocumentFile file = documentFileRepository.findByDocumentId(document.getId())
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서 파일 메타데이터를 찾을 수 없습니다."));


### PR DESCRIPTION

/api/v1/documents/{id}/download 엔드포인트에서 403 해소