### PR TITLE
fix(chat): lazy download URL + hireDate context to AI

### DIFF
--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageQueryService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageQueryService.java
@@ -18,9 +18,7 @@ import com.withbuddy.storage.entity.Document;
 import com.withbuddy.storage.entity.DocumentFile;
 import com.withbuddy.storage.repository.DocumentFileRepository;
 import com.withbuddy.storage.repository.DocumentRepository;
-import com.withbuddy.storage.service.DocumentDownloadService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -35,7 +33,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ChatMessageQueryService {
 
     private static final TypeReference<List<ChatMessageResponse.RecommendedContactResponse>> RECOMMENDED_CONTACTS_TYPE =
@@ -45,7 +42,6 @@ public class ChatMessageQueryService {
     private final ChatMessageDocumentRepository chatMessageDocumentRepository;
     private final DocumentRepository documentRepository;
     private final DocumentFileRepository documentFileRepository;
-    private final DocumentDownloadService documentDownloadService;
     private final ObjectMapper objectMapper;
     private final QuickQuestionCatalog quickQuestionCatalog;
     private final OnboardingSuggestionRepository onboardingSuggestionRepository;
@@ -192,12 +188,7 @@ public class ChatMessageQueryService {
     }
 
     private String resolveDownloadUrl(Document document, DocumentFile documentFile) {
-        try {
-            return documentDownloadService.getDownloadUrl(document, documentFile).getDownloadUrl();
-        } catch (RuntimeException ex) {
-            log.warn("문서 presigned URL 조회 실패. documentId={}, reason={}", document.getId(), ex.getMessage());
-            return "/api/v1/documents/" + document.getId() + "/download";
-        }
+        return "/api/v1/documents/" + document.getId() + "/download";
     }
 
     private List<QuickQuestionResponse> resolveQuickTaps(ChatMessage message) {

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -28,7 +28,6 @@ import com.withbuddy.storage.entity.Document;
 import com.withbuddy.storage.entity.DocumentFile;
 import com.withbuddy.storage.repository.DocumentFileRepository;
 import com.withbuddy.storage.repository.DocumentRepository;
-import com.withbuddy.storage.service.DocumentDownloadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -66,7 +65,6 @@ public class ChatMessageService {
     private final ChatMessageDocumentRepository chatMessageDocumentRepository;
     private final DocumentRepository documentRepository;
     private final DocumentFileRepository documentFileRepository;
-    private final DocumentDownloadService documentDownloadService;
     private final AiClient aiClient;
     private final RedisCacheService redisCacheService;
     private final ObjectMapper objectMapper;
@@ -79,6 +77,7 @@ public class ChatMessageService {
         String loginUserName = principal.name();
         String companyCode = principal.companyCode();
         String companyName = principal.companyName();
+        String hireDate = principal.hireDate();
         List<ConversationTurn> conversationHistory = sanitizeConversationHistoryForAi(
                 resolveConversationHistory(loginUserId)
         );
@@ -93,7 +92,8 @@ public class ChatMessageService {
                 loginUserId,
                 loginUserName,
                 companyCode,
-                companyName
+                companyName,
+                hireDate
         );
 
         AiAnswerServerRequest aiRequest = new AiAnswerServerRequest(
@@ -247,12 +247,7 @@ public class ChatMessageService {
     }
 
     private String resolveDownloadUrl(Document document, DocumentFile documentFile) {
-        try {
-            return documentDownloadService.getDownloadUrl(document, documentFile).getDownloadUrl();
-        } catch (RuntimeException ex) {
-            log.warn("문서 presigned URL 조회 실패. documentId={}, reason={}", document.getId(), ex.getMessage());
-            return "/api/v1/documents/" + document.getId() + "/download";
-        }
+        return "/api/v1/documents/" + document.getId() + "/download";
     }
 
     private Map<Long, Document> resolveDocumentMap(List<Long> documentIds) {

--- a/backend/src/main/java/com/withbuddy/global/jwt/JwtService.java
+++ b/backend/src/main/java/com/withbuddy/global/jwt/JwtService.java
@@ -70,6 +70,7 @@ public class JwtService {
                 .claim("name", user.getName())
                 .claim("companyCode", user.getCompany().getCompanyCode())
                 .claim("companyName", user.getCompany().getName())
+                .claim("hireDate", user.getHireDate().toString())
                 .issuedAt(now)
                 .expiration(expiry)
                 .signWith(secretKey)

--- a/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationFilter.java
@@ -68,7 +68,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     claims.get("employeeNumber", String.class),
                     claims.get("name", String.class),
                     claims.get("companyCode", String.class),
-                    claims.get("companyName", String.class)
+                    claims.get("companyName", String.class),
+                    claims.get("hireDate", String.class)
             );
 
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(

--- a/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationPrincipal.java
+++ b/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationPrincipal.java
@@ -5,6 +5,7 @@ public record JwtAuthenticationPrincipal(
         String employeeNumber,
         String name,
         String companyCode,
-        String companyName
+        String companyName,
+        String hireDate
 ) {
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/ai/dto/AiUserContext.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/ai/dto/AiUserContext.java
@@ -20,4 +20,7 @@ public class AiUserContext {
 
     @Schema(description = "회사명", example = "테크 주식회사")
     private String companyName;
+
+    @Schema(description = "입사일", example = "2026-04-01")
+    private String hireDate;
 }


### PR DESCRIPTION
## Summary\n- Return /api/v1/documents/{id}/download in chat payload (no eager presigned generation on message list load)\n- Keep presigned generation at download-click flow\n- Propagate hireDate through JWT principal to AiUserContext\n\n## Scope\n- Dedicated branch from main + cherry-pick only required commit\n\n## Verification\n- ackend: ./gradlew.bat compileJava (BUILD SUCCESSFUL)