### PR TITLE
feat(chat): async fallback on AI timeout

### DIFF
--- a/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageCreateResponse.java
+++ b/backend/src/main/java/com/withbuddy/chat/dto/ChatMessageCreateResponse.java
@@ -8,4 +8,11 @@ import lombok.Getter;
 public class ChatMessageCreateResponse {
     private ChatMessageResponse question;
     private ChatMessageResponse answer;
+    private String status;
+
+    public ChatMessageCreateResponse(ChatMessageResponse question, ChatMessageResponse answer) {
+        this.question = question;
+        this.answer = answer;
+        this.status = "COMPLETED";
+    }
 }

--- a/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/chat/service/ChatMessageService.java
@@ -19,6 +19,7 @@ import com.withbuddy.infrastructure.ai.dto.AiAnswerServerRequest;
 import com.withbuddy.infrastructure.ai.dto.AiAnswerServerResponse;
 import com.withbuddy.infrastructure.ai.dto.AiUserContext;
 import com.withbuddy.infrastructure.ai.dto.ConversationTurn;
+import com.withbuddy.infrastructure.ai.exception.AiTimeoutException;
 import com.withbuddy.infrastructure.redis.RedisCacheKeys;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.infrastructure.redis.RedisCacheTtl;
@@ -66,6 +67,7 @@ public class ChatMessageService {
     private final DocumentRepository documentRepository;
     private final DocumentFileRepository documentFileRepository;
     private final AiClient aiClient;
+    private final AsyncAiCallService asyncAiCallService;
     private final RedisCacheService redisCacheService;
     private final ObjectMapper objectMapper;
     private final TransactionTemplate transactionTemplate;
@@ -110,7 +112,21 @@ public class ChatMessageService {
                 Collections.emptyMap()
         );
 
-        AiAnswerServerResponse aiResponse = aiClient.requestAnswer(aiRequest);
+        AiAnswerServerResponse aiResponse;
+        try {
+            aiResponse = aiClient.requestAnswer(aiRequest);
+        } catch (AiTimeoutException timeoutException) {
+            Long questionId = savedQuestionMessage.getId();
+            redisCacheService.put(
+                    RedisCacheKeys.ragStatus(questionId),
+                    "PENDING",
+                    RedisCacheTtl.RAG_STATUS
+            );
+            asyncAiCallService.callAndSaveAnswer(questionId, loginUserId, aiRequest);
+            log.warn("AI 타임아웃 비동기 폴백. questionId={}", questionId);
+
+            return new ChatMessageCreateResponse(questionResponse, null, "PENDING");
+        }
 
         if (!savedQuestionMessage.getId().equals(aiResponse.getQuestionId())) {
             throw new IllegalStateException("AI 응답의 questionId가 저장된 질문 ID와 일치하지 않습니다.");
@@ -139,7 +155,8 @@ public class ChatMessageService {
 
         return new ChatMessageCreateResponse(
                 questionResponse,
-                toResponse(savedAnswerMessage, answerDocumentIds, documentMap, documentFileMap)
+                toResponse(savedAnswerMessage, answerDocumentIds, documentMap, documentFileMap),
+                "COMPLETED"
         );
     }
 

--- a/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AsyncAiRestClientConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/ai/config/AsyncAiRestClientConfig.java
@@ -13,7 +13,7 @@ public class AsyncAiRestClientConfig {
     public RestClient asyncAiRestClient(
             @Value("${ai.server.base-url}") String aiBaseUrl,
             @Value("${ai.server.connect-timeout-ms:5000}") int connectTimeoutMs,
-            @Value("${ai.server.async-read-timeout-ms:60000}") int asyncReadTimeoutMs
+            @Value("${ai.server.async-read-timeout-ms:15000}") int asyncReadTimeoutMs
     ) {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(connectTimeoutMs);

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -33,8 +33,8 @@ ai:
   server:
     base-url: ${AI_SERVER_BASE_URL}
     connect-timeout-ms: ${AI_SERVER_CONNECT_TIMEOUT_MS:5000}
-    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:30000}
-    async-read-timeout-ms: ${AI_SERVER_ASYNC_READ_TIMEOUT_MS:60000}
+    read-timeout-ms: ${AI_SERVER_READ_TIMEOUT_MS:10000}
+    async-read-timeout-ms: ${AI_SERVER_ASYNC_READ_TIMEOUT_MS:15000}
 
 app:
   security:


### PR DESCRIPTION
## Summary\n- Connect AsyncAiCallService as backend fallback when sync AI call times out\n- Return PENDING status in chat create response during fallback\n- Tune async AI read timeout to 15000ms in prod config\n\n## Verification\n- backend: ./gradlew.bat compileJava (BUILD SUCCESSFUL)\n\n## Cherry-pick\n- 4c31492a0c89d4da034ba5c59bfcc77c19fb12cc