### PR TITLE
Feature/scrum 249 redis failure logging (#785)

### DIFF
--- a/backend/src/main/java/com/withbuddy/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/withbuddy/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.withbuddy.global.jwt.SessionExpiredException;
 import com.withbuddy.global.jwt.SessionNotActiveException;
 import com.withbuddy.global.jwt.SessionRevokedException;
 import com.withbuddy.global.jwt.TokenMissingException;
+import com.withbuddy.global.logging.RedisFailureLogSupport;
 import com.withbuddy.infrastructure.ai.exception.AiTimeoutException;
 import com.withbuddy.storage.exception.StorageException;
 import com.withbuddy.account.user.exception.DuplicateEmployeeNumberException;
@@ -353,7 +354,7 @@ public class GlobalExceptionHandler {
                 request.getRequestURI()
         );
 
-        log.error("[REDIS_ERROR] path={}, message={}", request.getRequestURI(), e.getMessage(), e);
+        RedisFailureLogSupport.logRedisFailure(log, request, e);
 
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
     }

--- a/backend/src/main/java/com/withbuddy/global/logging/RedisFailureLogSupport.java
+++ b/backend/src/main/java/com/withbuddy/global/logging/RedisFailureLogSupport.java
@@ -1,0 +1,125 @@
+package com.withbuddy.global.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.withbuddy.global.security.JwtAuthenticationPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicLong;
+
+public final class RedisFailureLogSupport {
+
+    private static final AtomicLong REDIS_FAILURE_COUNT = new AtomicLong(0);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+
+    private RedisFailureLogSupport() {
+    }
+
+    public static void logRedisFailure(Logger log, HttpServletRequest request, Throwable throwable) {
+        long occurrence = REDIS_FAILURE_COUNT.incrementAndGet();
+        String failedAt = OffsetDateTime.now(ZoneOffset.UTC).toString();
+        UserIdentityHint userIdentityHint = resolveUserIdentityHint(request);
+
+        log.error(
+                "[REDIS_ERROR] failedAt={}, occurrence={}, method={}, path={}, userIdentifiable={}, userIdHint={}, clientIp={}, message={}",
+                failedAt,
+                occurrence,
+                request.getMethod(),
+                request.getRequestURI(),
+                userIdentityHint.userIdentifiable(),
+                userIdentityHint.userIdHint(),
+                resolveClientIp(request),
+                throwable.getMessage(),
+                throwable
+        );
+    }
+
+    private static UserIdentityHint resolveUserIdentityHint(HttpServletRequest request) {
+        String principalUserId = extractUserIdFromSecurityContext();
+        if (StringUtils.hasText(principalUserId)) {
+            return new UserIdentityHint(true, principalUserId);
+        }
+
+        String tokenUserId = extractUserIdFromAuthorizationHeader(request.getHeader(AUTHORIZATION_HEADER));
+        if (StringUtils.hasText(tokenUserId)) {
+            return new UserIdentityHint(true, tokenUserId);
+        }
+
+        return new UserIdentityHint(false, "-");
+    }
+
+    private static String extractUserIdFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof JwtAuthenticationPrincipal jwtPrincipal) {
+            return String.valueOf(jwtPrincipal.userId());
+        }
+
+        return null;
+    }
+
+    private static String extractUserIdFromAuthorizationHeader(String authorizationHeader) {
+        if (!StringUtils.hasText(authorizationHeader)) {
+            return null;
+        }
+
+        String trimmedHeader = authorizationHeader.trim();
+        if (!trimmedHeader.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            return null;
+        }
+
+        String token = trimmedHeader.substring(7).trim();
+        if (!StringUtils.hasText(token)) {
+            return null;
+        }
+
+        String[] tokenParts = token.split("\\.");
+        if (tokenParts.length < 2) {
+            return null;
+        }
+
+        try {
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(tokenParts[1]);
+            JsonNode payload = OBJECT_MAPPER.readTree(new String(payloadBytes, StandardCharsets.UTF_8));
+            JsonNode subject = payload.get("sub");
+            if (subject == null || subject.isNull()) {
+                return null;
+            }
+
+            String userIdHint = subject.asText();
+            return StringUtils.hasText(userIdHint) ? userIdHint : null;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(X_FORWARDED_FOR_HEADER);
+        if (StringUtils.hasText(forwardedFor)) {
+            String[] forwardedValues = forwardedFor.split(",");
+            String firstIp = forwardedValues[0].trim();
+            if (StringUtils.hasText(firstIp)) {
+                return firstIp;
+            }
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    private record UserIdentityHint(boolean userIdentifiable, String userIdHint) {
+    }
+}

--- a/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import com.withbuddy.global.jwt.JwtService;
 import com.withbuddy.global.jwt.SessionExpiredException;
 import com.withbuddy.global.jwt.SessionRevokedException;
 import com.withbuddy.global.jwt.TokenMissingException;
+import com.withbuddy.global.logging.RedisFailureLogSupport;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -87,7 +88,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (RedisConnectionFailureException | QueryTimeoutException e) {
-            log.error("[REDIS_ERROR] path={}, message={}", request.getRequestURI(), e.getMessage(), e);
+            RedisFailureLogSupport.logRedisFailure(log, request, e);
             writeServiceUnavailable(response, request.getRequestURI());
             return;
         } catch (TokenMissingException e) {

--- a/backend/src/test/java/com/withbuddy/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/withbuddy/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,32 @@
+package com.withbuddy.global.exception;
+
+import com.withbuddy.global.dto.ErrorResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    @Test
+    void mapsRedisConnectionFailureToSessionStoreUnavailable503() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/auth/logout");
+
+        ResponseEntity<ErrorResponse> response = handler.handleRedisConnectionFailureException(
+                new RedisConnectionFailureException("redis down"),
+                request
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(503);
+        assertThat(response.getBody().getCode()).isEqualTo("SESSION_STORE_UNAVAILABLE");
+        assertThat(response.getBody().getPath()).isEqualTo("/api/v1/auth/logout");
+        assertThat(response.getBody().getErrors()).isNotEmpty();
+        assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("server");
+    }
+}

--- a/backend/src/test/java/com/withbuddy/global/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/withbuddy/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,72 @@
+package com.withbuddy.global.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.withbuddy.global.jwt.JwtService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtService jwtService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void returns503WhenRedisConnectionFailsDuringAuthentication() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
+        request.addHeader("Authorization", "Bearer test-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        when(jwtService.extractBearerToken("Bearer test-token")).thenReturn("test-token");
+        when(jwtService.getClaims("test-token"))
+                .thenThrow(new RedisConnectionFailureException("redis connection failed"));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(chain.getRequest()).isNull();
+
+        JsonNode body = objectMapper.readTree(response.getContentAsString());
+        assertThat(body.get("code").asText()).isEqualTo("SESSION_STORE_UNAVAILABLE");
+        assertThat(body.get("status").asInt()).isEqualTo(503);
+        assertThat(body.get("path").asText()).isEqualTo("/api/v1/chat/messages");
+        assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("server");
+    }
+
+    @Test
+    void returns503WhenRedisQueryTimeoutOccursDuringAuthentication() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
+        request.addHeader("Authorization", "Bearer test-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        when(jwtService.extractBearerToken("Bearer test-token")).thenReturn("test-token");
+        when(jwtService.getClaims("test-token"))
+                .thenThrow(new QueryTimeoutException("redis query timeout"));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(chain.getRequest()).isNull();
+
+        JsonNode body = objectMapper.readTree(response.getContentAsString());
+        assertThat(body.get("code").asText()).isEqualTo("SESSION_STORE_UNAVAILABLE");
+        assertThat(body.get("status").asInt()).isEqualTo(503);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- Feature/scrum 249 redis failure logging (#785)
- test(auth): add redis 503 handling tests and fix EventTarget package
- feat(chat): SCRUM-249 redis failure log context 강화

## 검증
- ./gradlew.bat test --tests "com.withbuddy.global.security.JwtAuthenticationFilterTest" --tests "com.withbuddy.global.exception.GlobalExceptionHandlerTest"
- 결과: BUILD SUCCESSFUL
