### PR TITLE
ci(backend): oci-cli 검증에 host OCI_REGION fallback 허용

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -159,11 +159,11 @@ jobs:
           fi
 
           # OCI pre-signed URL 생성 조건 검증
+          # STORAGE_* 값이 없더라도 런타임에서 host-level OCI_REGION을 사용할 수 있으므로 배포 자체는 차단하지 않는다.
           if [ "${STORAGE_PROVIDER}" = "oci-cli" ] && \
              [ -z "${STORAGE_OCI_REGION:-}" ] && \
              [ -z "${STORAGE_OCI_PUBLIC_ENDPOINT:-}" ]; then
-            echo "Missing required secrets for oci-cli provider: set STORAGE_OCI_REGION or STORAGE_OCI_PUBLIC_ENDPOINT."
-            exit 1
+            echo "WARN: STORAGE_OCI_REGION/STORAGE_OCI_PUBLIC_ENDPOINT not set. Runtime will rely on OCI_REGION from backend host environment."
           fi
 
       - name: Debug Cloudflare Access SSH (temporary)


### PR DESCRIPTION
## 변경 사항
- backend-deploy.yml의 oci-cli 사전 검증에서 STORAGE_OCI_REGION/STORAGE_OCI_PUBLIC_ENDPOINT 미설정 시 hard fail 제거
- 대신 경고 로그 출력 후 배포 진행

## 배경
- 런타임 스토리지 클라이언트는 OCI_REGION(host-level env) fallback을 지원함
- 기존 검증은 이 경로를 차단하여 유효한 런타임 구성을 CI 단계에서 실패시키는 문제(P2) 존재