### PR TITLE
ci(backend): health alert 스크립트 자동 배포 반영 (#791)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -9,6 +9,7 @@ on:
       - main
     paths:
       - "backend/**"
+      - "scripts/discord-health-alert.sh"
       - ".github/workflows/backend-deploy.yml"
   workflow_dispatch:
     inputs:
@@ -269,6 +270,31 @@ jobs:
           set -euo pipefail
           ssh "${BACKEND_ACCESS_HOST}" "mkdir -p '${BACKEND_APP_DIR}'"
           scp app.jar "${BACKEND_ACCESS_HOST}:${BACKEND_APP_DIR}/app.jar"
+
+      - name: Upload health alert script to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.BACKEND_SERVER_HOST }}
+          username: ${{ secrets.BACKEND_SERVER_USER }}
+          key: ${{ secrets.BACKEND_SERVER_SSH_KEY }}
+          source: "scripts/discord-health-alert.sh"
+          target: ${{ secrets.BACKEND_APP_DIR }}
+          overwrite: true
+
+      - name: Ensure health alert script permissions
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          BACKEND_APP_DIR: ${{ secrets.BACKEND_APP_DIR }}
+        with:
+          host: ${{ secrets.BACKEND_SERVER_HOST }}
+          username: ${{ secrets.BACKEND_SERVER_USER }}
+          key: ${{ secrets.BACKEND_SERVER_SSH_KEY }}
+          envs: BACKEND_APP_DIR
+          script: |
+            set -euo pipefail
+            APP_DIR="${BACKEND_APP_DIR}"
+            mkdir -p "${APP_DIR}/scripts" "${APP_DIR}/logs"
+            chmod +x "${APP_DIR}/scripts/discord-health-alert.sh"
 
       - name: Repair Flyway failed migrations
         env:

--- a/.github/workflows/pr-autofill.yml
+++ b/.github/workflows/pr-autofill.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   autofill:
     runs-on: ubuntu-latest
-    env:
-      DISCORD_PR_WEBHOOK_URL: ${{ secrets.DISCORD_PR_WEBHOOK_URL }}
     steps:
       - name: Generate PR body from commit messages
         id: autofill_body
@@ -109,66 +107,3 @@ jobs:
 
             return body;
 
-      - name: Notify Discord with current PR body
-        if: ${{ env.DISCORD_PR_WEBHOOK_URL != '' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const { owner, repo } = context.repo;
-            const { data: latestPr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pr.number
-            });
-
-            const rawBody = latestPr.body || "";
-            const cleanedBody = rawBody
-              .replace(/<!-- AUTO_FILL_TEMPLATE -->/g, "")
-              .replace(/<!-- AUTO_FILL_COMMITS_START -->/g, "")
-              .replace(/<!-- AUTO_FILL_COMMITS_END -->/g, "")
-              .trim();
-
-            const prefix = [
-              `📌 PR 업데이트: #${pr.number} ${pr.title}`,
-              `Base: \`${pr.base.ref}\` ← Head: \`${pr.head.ref}\``,
-              pr.html_url,
-              ""
-            ].join("\n");
-
-            const maxDiscordContentLength = 2000;
-            const fallbackBody = cleanedBody || "(본문 없음)";
-            const buildContent = (bodyText) => `${prefix}\n${bodyText}`;
-
-            let bodyForContent = fallbackBody;
-            let content = buildContent(bodyForContent);
-            if (content.length > maxDiscordContentLength) {
-              const budget = Math.max(0, maxDiscordContentLength - prefix.length - 1);
-
-              if (budget === 0) {
-                content = prefix.slice(0, maxDiscordContentLength);
-              } else if (bodyForContent.length > budget) {
-                const ellipsis = "...";
-                const take = Math.max(0, budget - ellipsis.length);
-                bodyForContent = `${bodyForContent.slice(0, take)}${ellipsis}`;
-                content = buildContent(bodyForContent);
-              }
-
-              if (content.length > maxDiscordContentLength) {
-                content = content.slice(0, maxDiscordContentLength);
-              }
-            }
-
-            const res = await fetch(process.env.DISCORD_PR_WEBHOOK_URL, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                content,
-                allowed_mentions: { parse: [] }
-              })
-            });
-
-            if (!res.ok) {
-              const text = await res.text();
-              core.setFailed(`Discord webhook failed: ${res.status} ${text}`);
-            }

--- a/docs/operations/DISCORD_HEALTH_ALERT.md
+++ b/docs/operations/DISCORD_HEALTH_ALERT.md
@@ -18,7 +18,7 @@
 필수 환경변수:
 
 - `HEALTHCHECK_URL` (예: `http://127.0.0.1:8080/actuator/health`)
-- `DISCORD_WEBHOOK_URL` 또는 `DISCORD_PR_WEBHOOK_URL`
+- `DISCORD_WEBHOOK_URL`
 
 선택 환경변수:
 
@@ -48,8 +48,6 @@ ALERT_COOLDOWN_SECONDS=600
 OOM_CHECK_ENABLED=1
 OOM_LOOKBACK=5 minutes ago
 ```
-
-`DISCORD_WEBHOOK_URL`가 비어 있으면 `DISCORD_PR_WEBHOOK_URL`을 fallback으로 사용한다.
 
 ## 4) 수동 검증
 

--- a/scripts/discord-health-alert.sh
+++ b/scripts/discord-health-alert.sh
@@ -5,7 +5,7 @@ set -uo pipefail
 # 서버 헬스체크 + OOM 이벤트 감지 후 Discord Webhook 알림 스크립트
 
 HEALTHCHECK_URL="${HEALTHCHECK_URL:-}"
-DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-${DISCORD_PR_WEBHOOK_URL:-}}"
+DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-}"
 CHECK_NAME="${CHECK_NAME:-withbuddy-server}"
 
 CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
@@ -17,7 +17,7 @@ OOM_CHECK_ENABLED="${OOM_CHECK_ENABLED:-1}"
 OOM_LOOKBACK="${OOM_LOOKBACK:-5 minutes ago}"
 
 if [[ -z "$HEALTHCHECK_URL" || -z "$DISCORD_WEBHOOK_URL" ]]; then
-  echo "[error] HEALTHCHECK_URL and (DISCORD_WEBHOOK_URL or DISCORD_PR_WEBHOOK_URL) are required." >&2
+  echo "[error] HEALTHCHECK_URL and DISCORD_WEBHOOK_URL are required." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## 변경 사항\n- develop에 머지된 #791 커밋을 main 릴리즈 브랜치로 이관\n- backend deploy 워크플로우의 health alert 스크립트 자동 배포 반영\n\n## 포함 커밋\n- d5f5071 ci(backend): health alert 스크립트 자동 배포 반영 (#791)\n