### PR TITLE
feat(storage): 보안상 presigned URL를 API 응답시 미노출 처리

### DIFF
--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -486,10 +486,20 @@ public class DocumentStorageService implements DocumentDownloadService {
         StorageSource source = resolveSource(file);
         int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
         String redisKey = RedisCacheKeys.presignedUrl(file.getId(), source.name());
-        String downloadUrl = redisCacheService.get(redisKey)
+        String issuedUrl = redisCacheService.get(redisKey)
                 .filter(StringUtils::hasText)
                 .orElseGet(() -> createAndCacheDownloadUrl(documentId, file, source, redisKey, preauthTtlSeconds));
-        return new DocumentDownloadResponse(downloadUrl, preauthTtlSeconds, source.name());
+
+        if (StringUtils.hasText(issuedUrl) && issuedUrl.startsWith("http")) {
+            log.info(
+                    "Pre-signed download URL issued. documentId={}, source={}, url={}",
+                    documentId,
+                    source.name(),
+                    issuedUrl
+            );
+        }
+
+        return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source), preauthTtlSeconds, source.name());
     }
 
     private String createAndCacheDownloadUrl(
@@ -526,6 +536,10 @@ public class DocumentStorageService implements DocumentDownloadService {
                     safeMessage(e)
             );
         }
+        return "";
+    }
+
+    private String buildInternalDownloadUrl(Long documentId, StorageSource source) {
         return "/api/v1/documents/" + documentId + "/file?source=" + source.name();
     }
 

--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -492,10 +492,9 @@ public class DocumentStorageService implements DocumentDownloadService {
 
         if (StringUtils.hasText(issuedUrl) && issuedUrl.startsWith("http")) {
             log.info(
-                    "Pre-signed download URL issued. documentId={}, source={}, url={}",
+                    "Pre-signed download URL issued. documentId={}, source={}",
                     documentId,
-                    source.name(),
-                    issuedUrl
+                    source.name()
             );
         }
 

--- a/docs/api/API_CURRENT.md
+++ b/docs/api/API_CURRENT.md
@@ -2317,6 +2317,8 @@ Authorization: Bearer {accessToken}
 - 파일 메타데이터 및 실제 저장 위치는 `document_files`를 기준으로 조회한다.
 - 운영 환경에서는 스토리지 기반 다운로드 URL 또는 파일 접근 경로를 반환할 수 있다.
 - 로컬 개발 환경에서는 `/api/v1/documents/{documentId}/file` 경로를 다운로드 URL로 반환할 수 있다.
+- pre-signed URL은 서버 내부 스토리지 접근/로깅에만 사용하고, API 응답 본문에는 노출하지 않는다.
+- 보안상 pre-signed URL에는 단기 접근 토큰이 포함되므로, URL 유출 시 만료 전까지 제3자 다운로드가 가능해 응답 노출을 제한한다.
 - `document_type != TEMPLATE`인 경우에는 정책에 따라 `400 Bad Request` 또는 `404 Not Found`를 반환한다.
 
 #### Response (200 OK)


### PR DESCRIPTION
<!-- AUTO_FILL_COMMITS_START -->
## 변경 사항
- feat(storage): keep presigned URL in server logs and hide from API response
- fix(storage): remove presigned URL token from info logs
<!-- AUTO_FILL_COMMITS_END -->