### PR TITLE
feat(ai): BM25 하이브리드 검색 도입 및 1주차 기반 정비 (#825)

### DIFF
--- a/ai/core/vectorstore.py
+++ b/ai/core/vectorstore.py
@@ -6,13 +6,19 @@ ChromaDB를 로컬 디스크(./chroma_db)에 영구 저장하고 관리합니다
 싱글톤 패턴(@lru_cache)으로 앱 실행 중 한 번만 연결합니다.
 """
 
+import logging
 from functools import lru_cache
-from typing import List
+from typing import Any, List, Optional
 
 from langchain_chroma import Chroma
 from langchain_core.documents import Document
 from langchain_core.vectorstores import VectorStoreRetriever
 from core.embeddings import get_embeddings
+
+logger = logging.getLogger(__name__)
+
+# BM25 인덱스 캐시 (company_code → BM25Retriever)
+_bm25_cache: dict[str, Any] = {}
 
 # ChromaDB 영구 저장 경로
 CHROMA_DB_PATH = "./chroma_db"
@@ -68,6 +74,79 @@ def search_legal_docs(query: str, k: int = 7, score_threshold: float = 0.30) -> 
         query, k=k, filter={"document_type": "LEGAL"}
     )
     return [doc for doc, score in raw if score >= score_threshold]
+
+
+def _build_bm25_corpus(company_code: str) -> List[Document]:
+    """ChromaDB에서 회사+공통 문서 전체 로드 (BM25 코퍼스용)"""
+    vs = get_vectorstore()
+    col = vs._collection
+    docs: List[Document] = []
+
+    if company_code:
+        res = col.get(
+            where={"$and": [{"company_code": company_code}, {"document_type": {"$ne": "TEMPLATE"}}]},
+            include=["documents", "metadatas"],
+        )
+        for content, meta in zip(res["documents"], res["metadatas"]):
+            docs.append(Document(page_content=content, metadata=meta or {}))
+
+    common = col.get(
+        where={"$and": [{"company_code": ""}, {"document_type": {"$ne": "TEMPLATE"}}]},
+        include=["documents", "metadatas"],
+    )
+    for content, meta in zip(common["documents"], common["metadatas"]):
+        docs.append(Document(page_content=content, metadata=meta or {}))
+
+    return docs
+
+
+def get_bm25_retriever(company_code: str, k: int = 5) -> Optional[Any]:
+    """BM25Retriever 반환 (company_code별 캐시)"""
+    try:
+        from langchain_community.retrievers import BM25Retriever
+    except ImportError:
+        return None
+
+    if company_code not in _bm25_cache:
+        docs = _build_bm25_corpus(company_code)
+        if not docs:
+            _bm25_cache[company_code] = None
+        else:
+            _bm25_cache[company_code] = BM25Retriever.from_documents(docs)
+            logger.info("BM25 인덱스 생성: %s (%d개 문서)", company_code or "공통", len(docs))
+
+    retriever = _bm25_cache[company_code]
+    if retriever is None:
+        return None
+    retriever.k = k
+    return retriever
+
+
+def invalidate_bm25_cache(company_code: str = "") -> None:
+    """문서 추가/삭제 후 BM25 캐시 무효화"""
+    if company_code:
+        _bm25_cache.pop(company_code, None)
+    else:
+        _bm25_cache.clear()
+
+
+def _rrf_merge(vec_docs: List[Document], bm25_docs: List[Document], k: int) -> List[Document]:
+    """Reciprocal Rank Fusion으로 벡터 + BM25 결과 병합"""
+    scores: dict[str, float] = {}
+    doc_map: dict[str, Document] = {}
+
+    for rank, doc in enumerate(vec_docs):
+        key = doc.page_content[:120]
+        scores[key] = scores.get(key, 0.0) + 1.0 / (rank + 60)
+        doc_map[key] = doc
+
+    for rank, doc in enumerate(bm25_docs):
+        key = doc.page_content[:120]
+        scores[key] = scores.get(key, 0.0) + 1.0 / (rank + 60)
+        doc_map[key] = doc
+
+    ranked = sorted(scores, key=lambda x: scores[x], reverse=True)
+    return [doc_map[key] for key in ranked[:k]]
 
 
 def search_with_company_fallback(query: str, k: int = 5, company_code: str = "", score_threshold: float = 0.30, category: str = "") -> List[Document]:
@@ -129,5 +208,15 @@ def search_with_company_fallback(query: str, k: int = 5, company_code: str = "",
 
     if not merged:
         return []
+
+    # BM25 하이브리드 검색 병합 (실패 시 벡터 결과 그대로 반환)
+    if company_code:
+        try:
+            bm25 = get_bm25_retriever(company_code, k=k)
+            if bm25:
+                bm25_results = bm25.invoke(query)
+                return _rrf_merge(merged, bm25_results, k)
+        except Exception as e:
+            logger.warning("BM25 검색 실패, 벡터 결과만 사용: %s", e)
 
     return merged[:k]

--- a/ai/requirements.txt
+++ b/ai/requirements.txt
@@ -7,6 +7,7 @@ langchain>=0.3.0
 langchain-core>=0.3.0
 langchain-text-splitters>=0.3.0
 langchain-community>=0.3.0
+rank-bm25>=0.2.2                  # BM25 하이브리드 검색
 langchain-anthropic>=0.3.0        # Claude API 연동
 langchain-huggingface>=0.1.0      # HuggingFace 임베딩 (리랭커 모델용으로 유지)
 langchain-google-genai>=2.0.0     # Gemini Embedding 2

--- a/ai/routers/admin.py
+++ b/ai/routers/admin.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from langchain_core.documents import Document
 from pydantic import BaseModel, Field
 
-from core.vectorstore import get_vectorstore
+from core.vectorstore import get_vectorstore, invalidate_bm25_cache
 
 _COMPANY_INFO_PATH = Path(__file__).parent.parent / "data" / "company_info.json"
 
@@ -285,6 +285,7 @@ async def upload_document(file: UploadFile = File(...), company_code: str = Form
 
     vs = get_vectorstore()
     vs.add_documents(docs)
+    invalidate_bm25_cache(company_code)
 
     return {
         "message": f"'{filename}' 업로드 및 인덱싱 완료",
@@ -321,5 +322,6 @@ async def delete_document(filename: str):
 
     # 파일 삭제
     file_path.unlink()
+    invalidate_bm25_cache()
 
     return {"message": f"'{filename}' 삭제 완료"}

--- a/ai/tasks/scheduler.py
+++ b/ai/tasks/scheduler.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 async def _keepalive_llm() -> None:
-    """LLM 콜드 스타트 방지 — 30분마다 최소 호출로 연결 유지"""
+    """LLM 콜드 스타트 방지 — 1시간마다 최소 호출로 연결 유지"""
     try:
         from core.llm import get_llm
         await asyncio.to_thread(get_llm().invoke, "ping")
@@ -57,12 +57,12 @@ def start_scheduler() -> None:
     _scheduler.add_job(
         _keepalive_llm,
         "interval",
-        minutes=30,
+        minutes=60,
         id="llm_keepalive",
         replace_existing=True,
     )
     _scheduler.start()
-    logger.info("스케줄러 시작 — 평일 17:00 리포트 / 09:00 My Buddy 체크인 / 30분 LLM keep-alive 활성화")
+    logger.info("스케줄러 시작 — 평일 17:00 리포트 / 09:00 My Buddy 체크인 / 60분 LLM keep-alive 활성화")
 
 
 def stop_scheduler() -> None:


### PR DESCRIPTION
* feat(ai): BM25 하이브리드 검색 도입 및 1주차 기반 정비

- vectorstore.py: BM25Retriever + RRF 병합으로 하이브리드 검색 구현
  - _build_bm25_corpus(): ChromaDB 전체 문서 로드
  - get_bm25_retriever(): company_code별 BM25 인덱스 캐시
  - _rrf_merge(): Reciprocal Rank Fusion으로 벡터+BM25 결과 병합
  - invalidate_bm25_cache(): 문서 변경 시 캐시 무효화
- requirements.txt: rank-bm25>=0.2.2 추가
- scheduler.py: LLM keepalive 60분 간격으로 조정
- scripts: IN SCOPE 1주차 베이스라인 결과 추가 (50/50, 100%)

* fix(ai): BM25 실패 시 벡터 결과 fallback 처리
* fix(ai): 문서 업로드/삭제 시 BM25 캐시 무효화


