### PR TITLE
[SCRUM-366] 다운로드 접근 차단/감사 로그 정책 및 Loki 운영 가이드

### DIFF
--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -498,9 +498,9 @@ public class DocumentStorageService implements DocumentDownloadService {
                     documentId,
                     source.name()
             );
+            logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, source, preauthTtlSeconds, null, "REDIRECT");
         }
 
-        logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, source, preauthTtlSeconds, null, "REDIRECT");
         return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source), preauthTtlSeconds, source.name());
     }
 

--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -30,6 +30,7 @@ import com.withbuddy.storage.repository.DocumentRepository;
 import com.withbuddy.global.security.JwtAuthenticationPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -80,6 +81,7 @@ public class DocumentStorageService implements DocumentDownloadService {
 
     private record RequesterScope(
             String companyCode,
+            Long userId,
             boolean globalAccess
     ) {
     }
@@ -498,6 +500,7 @@ public class DocumentStorageService implements DocumentDownloadService {
             );
         }
 
+        logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, source, preauthTtlSeconds, null, "REDIRECT");
         return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source), preauthTtlSeconds, source.name());
     }
 
@@ -524,6 +527,13 @@ public class DocumentStorageService implements DocumentDownloadService {
             );
 
             if (StringUtils.hasText(preSignedUrl)) {
+                redisCacheService.put(redisKey, preSignedUrl, Duration.ofSeconds(preauthTtlSeconds));
+                log.info(
+                        "Pre-signed URL generated. documentId={}, source={}, ttlSeconds={}",
+                        documentId,
+                        source.name(),
+                        preauthTtlSeconds
+                );
                 redisCacheService.put(redisKey, preSignedUrl, Duration.ofSeconds(preauthTtlSeconds));
                 return preSignedUrl;
             }
@@ -560,10 +570,14 @@ public class DocumentStorageService implements DocumentDownloadService {
             if (!StringUtils.hasText(file.getBackupObjectKey())) {
                 throw new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "source", "백업 파일을 찾을 수 없습니다.");
             }
-            return objectStorageClient.getObject(file.getBackupNamespace(), file.getBackupBucket(), file.getBackupObjectKey());
+            byte[] payload = objectStorageClient.getObject(file.getBackupNamespace(), file.getBackupBucket(), file.getBackupObjectKey());
+            logDownloadAuditEvent("DOWNLOAD_CONTENT_ACCESSED", requesterScope, document, source, null, payload.length, "DIRECT");
+            return payload;
         }
 
-        return objectStorageClient.getObject(file.getPrimaryNamespace(), file.getPrimaryBucket(), file.getPrimaryObjectKey());
+        byte[] payload = objectStorageClient.getObject(file.getPrimaryNamespace(), file.getPrimaryBucket(), file.getPrimaryObjectKey());
+        logDownloadAuditEvent("DOWNLOAD_CONTENT_ACCESSED", requesterScope, document, source, null, payload.length, "DIRECT");
+        return payload;
     }
 
     public String resolveDownloadFileName(Long documentId) {
@@ -903,7 +917,7 @@ public class DocumentStorageService implements DocumentDownloadService {
 
         Object principal = authentication.getPrincipal();
         if (principal instanceof StorageApiKeyPrincipal storagePrincipal) {
-            return new RequesterScope(null, storagePrincipal.globalAccess());
+            return new RequesterScope(null, null, storagePrincipal.globalAccess());
         }
         return null;
     }
@@ -936,9 +950,44 @@ public class DocumentStorageService implements DocumentDownloadService {
                 throw new ForbiddenException("ACCESS_DENIED", "role", "관리자 권한이 필요한 API입니다.");
             }
 
-            return new RequesterScope(currentUser.getCompany().getCompanyCode(), false);
+            return new RequesterScope(currentUser.getCompany().getCompanyCode(), currentUser.getId(), false);
         }
         return null;
+    }
+
+    private void logDownloadAuditEvent(
+            String event,
+            RequesterScope requesterScope,
+            Document document,
+            StorageSource source,
+            Integer ttlSeconds,
+            Integer contentLength,
+            String route
+    ) {
+        String userId = requesterScope.userId() == null ? "SYSTEM" : String.valueOf(requesterScope.userId());
+        String requesterCompanyCode = StringUtils.hasText(requesterScope.companyCode()) ? requesterScope.companyCode() : "GLOBAL";
+        String documentCompanyCode = StringUtils.hasText(document.getCompanyCode()) ? document.getCompanyCode() : "COMMON";
+        String traceId = resolveTraceId();
+
+        log.info(
+                "AUDIT_DOWNLOAD event={} route={} userId={} requesterCompanyCode={} documentCompanyCode={} documentId={} source={} ttlSeconds={} contentLength={} globalAccess={} traceId={}",
+                event,
+                route,
+                userId,
+                requesterCompanyCode,
+                documentCompanyCode,
+                document.getId(),
+                source.name(),
+                ttlSeconds == null ? "-" : ttlSeconds,
+                contentLength == null ? "-" : contentLength,
+                requesterScope.globalAccess(),
+                traceId
+        );
+    }
+
+    private String resolveTraceId() {
+        String traceId = MDC.get("traceId");
+        return StringUtils.hasText(traceId) ? traceId : "-";
     }
 
     private void compensatePrimaryObject(String namespace, String bucket, String objectKey, Exception rootCause) {

--- a/docs/api/API_CURRENT.md
+++ b/docs/api/API_CURRENT.md
@@ -2477,6 +2477,8 @@ Authorization: Bearer {accessToken}
 - 파일 메타데이터 및 실제 저장 위치는 `document_files`를 기준으로 조회한다.
 - 응답 `downloadUrl`에는 내부 경로(`/api/v1/documents/{documentId}/file?source=...`)만 반환한다.
 - pre-signed URL은 `/file` 호출 시점에만 생성되어 `302 Location`으로 전달된다.
+- 다운로드 감사 로그는 `AUDIT_DOWNLOAD` 구조화 로그로 기록되며, pre-signed URL 원문은 로그에 남기지 않는다.
+- Grafana/Loki 운영 쿼리는 `docs/operations/storage/AUDIT_DOWNLOAD_GRAFANA_LOKI.md`를 따른다.
 - 응답의 `expiresIn`은 현재 pre-signed URL 유효시간(기본 30초)을 의미한다.
 - 응답의 `source`는 실제 다운로드에 사용할 스토리지 소스(`PRIMARY` 또는 `BACKUP`)다.
 - `document_type != TEMPLATE`인 경우에는 정책에 따라 `400 Bad Request` 또는 `404 Not Found`를 반환한다.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -8,6 +8,8 @@
 - [storage/README.md](./storage/README.md): 스토리지 운영 문서 인덱스
 - [storage/RUNBOOK.md](./storage/RUNBOOK.md): Storage API 운영 런북
 - [storage/OPS_LOG_2026-04-11_OBJECT_STORAGE.md](./storage/OPS_LOG_2026-04-11_OBJECT_STORAGE.md): Object Storage 작업 로그
+- [storage/AUDIT_DOWNLOAD_GRAFANA_LOKI.md](./storage/AUDIT_DOWNLOAD_GRAFANA_LOKI.md): 다운로드 감사 로그 Grafana/Loki 쿼리 및 알림 가이드
+- [storage/DOWNLOAD_ACCESS_POLICY.md](./storage/DOWNLOAD_ACCESS_POLICY.md): 다운로드 접근 차단 및 감사 로그 정책(SCRUM-366)
 
 ## 관리 원칙
 

--- a/docs/operations/storage/AUDIT_DOWNLOAD_GRAFANA_LOKI.md
+++ b/docs/operations/storage/AUDIT_DOWNLOAD_GRAFANA_LOKI.md
@@ -1,0 +1,118 @@
+# AUDIT_DOWNLOAD Grafana/Loki 운영 가이드
+
+`AUDIT_DOWNLOAD` 구조화 로그를 기준으로 문서 다운로드 경로를 모니터링하는 표준 쿼리/알림 규칙입니다.
+
+## KPI/OKR 정의
+
+| 항목 | 내용 |
+| --- | --- |
+| 목표 KPI | 다운로드 감사 로그 누락률 0%, URL 발급 성공 이벤트(`DOWNLOAD_URL_ISSUED`) 수집율 100% |
+| OKR 연결 | 문서 다운로드 추적 가능성 확보로 보안/감사 대응 리드타임 단축 |
+| 평가셋 | 운영 트래픽 기준 48시간, Loki 수집 정상, Backend 인스턴스 1개 이상 |
+| Before/After | Before: presigned URL 원문 로그 중심, 감사 필드 집계 어려움 / After: `AUDIT_DOWNLOAD` 키-값 집계 가능 |
+| 합격 기준 | 48시간 동안 `AUDIT_DOWNLOAD` 파싱 실패 0건, 대시보드/알림 정상 동작 |
+
+## 로그 포맷
+
+Backend 로그 예시:
+
+```text
+AUDIT_DOWNLOAD event=DOWNLOAD_URL_ISSUED route=REDIRECT userId=101 requesterCompanyCode=COMPANY_A documentCompanyCode=COMPANY_A documentId=55 source=PRIMARY ttlSeconds=30 contentLength=- globalAccess=false traceId=...
+```
+
+필드:
+- `event`: `DOWNLOAD_URL_ISSUED` 또는 `DOWNLOAD_CONTENT_ACCESSED`
+- `route`: `REDIRECT` 또는 `DIRECT`
+- `userId`: JWT 사용자 ID, API Key 기반 호출은 `SYSTEM`
+- `requesterCompanyCode`, `documentCompanyCode`
+- `documentId`, `source`, `ttlSeconds`, `contentLength`, `globalAccess`, `traceId`
+
+## Loki LogQL 쿼리
+
+아래에서 라벨 셀렉터는 환경에 맞게 바꿉니다.
+- 예시: `{app="withbuddy-backend", env="prod"}`
+
+### 1) 최근 15분 감사 로그 원문
+
+```logql
+{app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD"
+```
+
+### 2) URL 발급 이벤트 건수 (1분 버킷)
+
+```logql
+sum by (source) (
+  count_over_time({app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD" | logfmt | event="DOWNLOAD_URL_ISSUED" [1m])
+)
+```
+
+### 3) 실제 다운로드 이벤트 건수 (1분 버킷)
+
+```logql
+sum by (source) (
+  count_over_time({app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD" | logfmt | event="DOWNLOAD_CONTENT_ACCESSED" [1m])
+)
+```
+
+### 4) 회사별 다운로드 TOP N (최근 1시간)
+
+```logql
+topk(10,
+  sum by (documentCompanyCode) (
+    count_over_time({app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD" | logfmt | event="DOWNLOAD_CONTENT_ACCESSED" [1h])
+  )
+)
+```
+
+### 5) API Key 경로(SYSTEM) 사용량 (최근 15분)
+
+```logql
+sum(
+  count_over_time({app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD" | logfmt | userId="SYSTEM" [15m])
+)
+```
+
+### 6) 파싱 실패 탐지 (포맷 이상)
+
+```logql
+sum(
+  count_over_time({app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD" | logfmt | __error__!="" [5m])
+)
+```
+
+## Grafana 알림 권장안
+
+### Alert A: 감사 로그 파싱 실패
+- 조건: 쿼리 6 결과 `> 0` for 5m
+- 심각도: warning
+- 의미: 로그 포맷 훼손 또는 수집 파이프라인 파싱 오류
+
+### Alert B: 감사 로그 유입 중단
+- 조건:
+```logql
+sum(count_over_time({app="withbuddy-backend", env="prod"} |= "AUDIT_DOWNLOAD" [10m])) == 0
+```
+- for: 10m
+- 심각도: critical
+- 의미: 다운로드 트래픽 급감 또는 로그 수집/애플리케이션 장애
+
+### Alert C: API Key 경로 급증
+- 조건: 쿼리 5 결과가 평시 기준치 초과(예: `> 50` / 15m)
+- 심각도: warning
+- 의미: 비정상 자동 호출 또는 내부 연계 이상 가능성
+
+## 대시보드 패널 구성 권장
+
+1. `Downloads Issued per Minute` (쿼리 2, 시계열)
+2. `Downloads Accessed per Minute` (쿼리 3, 시계열)
+3. `Top Companies (1h)` (쿼리 4, 바 차트)
+4. `SYSTEM Access Count (15m)` (쿼리 5, Stat)
+5. `Parse Errors (5m)` (쿼리 6, Stat + Alert)
+
+## 운영 체크리스트 (배포 후 48시간)
+
+1. 쿼리 1에서 `AUDIT_DOWNLOAD` 로그가 실시간 유입되는지 확인
+2. 쿼리 6 값이 지속적으로 `0`인지 확인
+3. 쿼리 2/3 추이가 비정상적으로 벌어지지 않는지 확인
+4. Alert A/B/C 테스트 알림 1회 송신 확인
+

--- a/docs/operations/storage/DOWNLOAD_ACCESS_POLICY.md
+++ b/docs/operations/storage/DOWNLOAD_ACCESS_POLICY.md
@@ -1,0 +1,92 @@
+# 문서 다운로드 접근 차단 및 감사 로그 정책
+
+SCRUM-366 정책 확정 문서입니다. 삭제·비활성화 문서 접근 차단 정책과 다운로드 감사 로그 정책을 정의합니다.
+
+## 1. 삭제·비활성화 문서 접근 차단 정책
+
+### 정책 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 적용 대상 | 다운로드 URL 발급, Redirect 다운로드, Direct 파일 다운로드 진입 경로 |
+| 차단 조건 | `documents.is_active = false` |
+| 차단 결과 | `404 Not Found` / `NOT_FOUND` |
+| 구현 위치 | `DocumentStorageService`의 다운로드 관련 조회 경로 |
+
+### 구현 원칙
+
+- 문서 조회는 `findByIdAndIsActiveTrue`를 사용한다.
+- `is_active = false` 문서는 조회 단계에서 제외되어 실제 파일 접근 전 차단된다.
+- 클라이언트에는 삭제 여부를 노출하지 않고 동일하게 `NOT_FOUND`를 반환한다.
+
+예시:
+
+```java
+documentRepository.findByIdAndIsActiveTrue(documentId)
+    .orElseThrow(() -> new StorageException(
+        HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서를 찾을 수 없습니다."));
+```
+
+### 적용 엔드포인트
+
+| 경로 | 역할 | 차단 적용 |
+| --- | --- | --- |
+| `GET /api/v1/documents/{id}/download` | 다운로드 URL 발급 | ✅ |
+| `GET /api/v1/documents/{id}/file?source=...` | 302 Redirect 다운로드 | ✅ |
+| `GET /api/v1/documents/{id}/file?source=...` | Direct 바이트 다운로드 | ✅ |
+
+## 2. 감사 로그 정책
+
+### 정책 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 로그 키워드 | `AUDIT_DOWNLOAD` |
+| 저장 방식 | 애플리케이션 구조화 로그 |
+| 수집 경로 | Logback → Loki (Grafana 조회) |
+| 기록 시점 | URL 발급 성공, 실제 파일 반환 성공 |
+| 보안 원칙 | presigned URL 원문 로그 금지 |
+
+### 저장 필드
+
+| 필드 | 값 예시 | 설명 |
+| --- | --- | --- |
+| `event` | `DOWNLOAD_URL_ISSUED`, `DOWNLOAD_CONTENT_ACCESSED` | 이벤트 유형 |
+| `route` | `REDIRECT`, `DIRECT` | 다운로드 경로 |
+| `userId` | `101`, `SYSTEM` | JWT 사용자 ID, API Key 호출은 `SYSTEM` |
+| `requesterCompanyCode` | `COMPANY_A`, `GLOBAL` | 요청자 회사 코드 |
+| `documentCompanyCode` | `COMPANY_A`, `COMMON` | 문서 회사 코드 |
+| `documentId` | `55` | 문서 ID |
+| `source` | `PRIMARY`, `BACKUP` | 저장소 소스 |
+| `ttlSeconds` | `30`, `-` | Redirect URL 유효시간 |
+| `contentLength` | `204800`, `-` | Direct 응답 바이트 길이 |
+| `globalAccess` | `true`, `false` | API Key globalAccess 여부 |
+| `traceId` | `abc-123`, `-` | MDC traceId |
+| `timestamp` | Logback 자동 부여 | Loki 시간 인덱싱 기준 |
+
+로그 예시:
+
+```text
+AUDIT_DOWNLOAD event=DOWNLOAD_URL_ISSUED route=REDIRECT userId=101 requesterCompanyCode=COMPANY_A documentCompanyCode=COMPANY_A documentId=55 source=PRIMARY ttlSeconds=30 contentLength=- globalAccess=false traceId=abc-def-123
+```
+
+## 3. 의도적 제외 범위
+
+| 항목 | 이유 |
+| --- | --- |
+| 다운로드 실패 이벤트 별도 감사 레코드 | 예외 경로는 기존 ERROR/WARN 로그로 추적 |
+| presigned URL 원문 로그 | 임시 권한 토큰 노출 방지 |
+| 별도 감사 DB 테이블 | 현재 범위에서는 Loki 기반 감사로 운영 |
+
+## 4. 운영 KPI 및 검증 기준
+
+| 항목 | 기준 |
+| --- | --- |
+| 목표 KPI | `AUDIT_DOWNLOAD` 파싱 실패 0건, 유효 이벤트 수집률 100% |
+| 평가셋 | 운영 트래픽 기준 48시간, Loki 수집 정상 |
+| 합격 기준 | 대시보드/알림 정상 동작, 파싱 실패 알림 0건 |
+
+Grafana/Loki 쿼리와 알림 규칙은 [AUDIT_DOWNLOAD_GRAFANA_LOKI.md](./AUDIT_DOWNLOAD_GRAFANA_LOKI.md)를 따른다.
+
+_정책 확정일: 2026-05-19 / SCRUM-366_
+

--- a/docs/operations/storage/README.md
+++ b/docs/operations/storage/README.md
@@ -6,6 +6,8 @@
 
 - [RUNBOOK.md](./RUNBOOK.md): Storage API 운영 및 장애 대응 절차
 - [OPS_LOG_2026-04-11_OBJECT_STORAGE.md](./OPS_LOG_2026-04-11_OBJECT_STORAGE.md): Object Storage 작업 이력
+- [AUDIT_DOWNLOAD_GRAFANA_LOKI.md](./AUDIT_DOWNLOAD_GRAFANA_LOKI.md): 다운로드 감사 로그 Grafana/Loki 쿼리 및 알림 가이드
+- [DOWNLOAD_ACCESS_POLICY.md](./DOWNLOAD_ACCESS_POLICY.md): 다운로드 접근 차단 및 감사 로그 정책(SCRUM-366)
 
 ## 관리 원칙
 


### PR DESCRIPTION
## 변경 사항\n- 다운로드 경로 AUDIT_DOWNLOAD 구조화 로그 추가\n- presigned URL 원문 로그 제거\n- 다운로드 감사 로그 Grafana/Loki 쿼리/알림 가이드 추가\n- 다운로드 접근 차단/감사 정책 문서(SCRUM-366) 추가\n- operations/storage 및 API 문서 링크 갱신\n\n## 기준 브랜치\n- base: develop\n- head: eat/scrum-366-audit-download-loki-develop\n\n## 참고\n- 이 PR은 origin/develop 대비 1커밋만 포함합니다.