### PR TITLE
fix(monitor): reduce false DOWN alerts with local fallback

### DIFF
--- a/scripts/discord-health-alert.sh
+++ b/scripts/discord-health-alert.sh
@@ -5,6 +5,7 @@ set -uo pipefail
 # 서버 헬스체크 + OOM 이벤트 감지 후 Discord Webhook 알림 스크립트
 
 HEALTHCHECK_URL="${HEALTHCHECK_URL:-}"
+LOCAL_HEALTHCHECK_URL="${LOCAL_HEALTHCHECK_URL:-}"
 DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-}"
 CHECK_NAME="${CHECK_NAME:-withbuddy-server}"
 
@@ -12,12 +13,18 @@ CURL_CONNECT_TIMEOUT="${CURL_CONNECT_TIMEOUT:-5}"
 CURL_MAX_TIME="${CURL_MAX_TIME:-10}"
 STATE_DIR="${STATE_DIR:-/tmp/withbuddy-monitor}"
 ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-600}"
+REQUIRED_DOWN_COUNT="${REQUIRED_DOWN_COUNT:-2}"
 
 OOM_CHECK_ENABLED="${OOM_CHECK_ENABLED:-1}"
 OOM_LOOKBACK="${OOM_LOOKBACK:-5 minutes ago}"
 
 if [[ -z "$HEALTHCHECK_URL" || -z "$DISCORD_WEBHOOK_URL" ]]; then
   echo "[error] HEALTHCHECK_URL and DISCORD_WEBHOOK_URL are required." >&2
+  exit 2
+fi
+
+if ! [[ "$REQUIRED_DOWN_COUNT" =~ ^[0-9]+$ ]] || [[ "$REQUIRED_DOWN_COUNT" -lt 1 ]]; then
+  echo "[error] REQUIRED_DOWN_COUNT must be a positive integer." >&2
   exit 2
 fi
 
@@ -36,6 +43,7 @@ mkdir -p "$STATE_DIR"
 
 health_state_file="$STATE_DIR/${safe_name}.health.state"
 down_alert_ts_file="$STATE_DIR/${safe_name}.down.last_alert_ts"
+down_count_file="$STATE_DIR/${safe_name}.down.count"
 oom_sig_file="$STATE_DIR/${safe_name}.oom.last_sig"
 
 now_utc() {
@@ -83,6 +91,11 @@ check_health() {
   local curl_err=""
   local curl_err_file
 
+  local local_http_code=""
+  local local_curl_rc=0
+  local local_curl_err=""
+  local local_is_up="0"
+
   curl_err_file="$(mktemp)"
   http_code="$(curl -sS \
     --connect-timeout "$CURL_CONNECT_TIMEOUT" \
@@ -96,6 +109,21 @@ check_health() {
   local is_up="0"
   if [[ "$curl_rc" -eq 0 && "$http_code" == "200" ]]; then
     is_up="1"
+  elif [[ -n "$LOCAL_HEALTHCHECK_URL" ]]; then
+    curl_err_file="$(mktemp)"
+    local_http_code="$(curl -sS \
+      --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+      --max-time "$CURL_MAX_TIME" \
+      -o /dev/null \
+      -w "%{http_code}" \
+      "$LOCAL_HEALTHCHECK_URL" 2>"$curl_err_file")" || local_curl_rc=$?
+    local_curl_err="$(tr '\n' ' ' <"$curl_err_file" | sed 's/[[:space:]]\+/ /g')"
+    rm -f "$curl_err_file"
+
+    if [[ "$local_curl_rc" -eq 0 && "$local_http_code" == "200" ]]; then
+      local_is_up="1"
+      is_up="1"
+    fi
   fi
 
   local prev_state="UP"
@@ -105,9 +133,26 @@ check_health() {
 
   if [[ "$is_up" == "1" ]]; then
     echo "UP" >"$health_state_file"
+    echo "0" >"$down_count_file"
     if [[ "$prev_state" == "DOWN" ]]; then
       send_discord "RECOVERY" "health check recovered (HTTP 200)"
     fi
+    return 0
+  fi
+
+  local prev_down_count=0
+  if [[ -f "$down_count_file" ]]; then
+    prev_down_count="$(cat "$down_count_file")"
+  fi
+  if ! [[ "$prev_down_count" =~ ^[0-9]+$ ]]; then
+    prev_down_count=0
+  fi
+
+  local current_down_count=$((prev_down_count + 1))
+  echo "$current_down_count" >"$down_count_file"
+
+  if [[ "$current_down_count" -lt "$REQUIRED_DOWN_COUNT" ]]; then
+    echo "UP" >"$health_state_file"
     return 0
   fi
 
@@ -122,7 +167,12 @@ check_health() {
 
   local elapsed=$((now_epoch - last_alert_epoch))
   if [[ "$prev_state" != "DOWN" || "$elapsed" -ge "$ALERT_COOLDOWN_SECONDS" ]]; then
-    if send_discord "DOWN" "http_code=${http_code}, curl_rc=${curl_rc}, err=${curl_err:-none}"; then
+    local detail
+    detail="http_code=${http_code}, curl_rc=${curl_rc}, err=${curl_err:-none}, down_count=${current_down_count}/${REQUIRED_DOWN_COUNT}"
+    if [[ -n "$LOCAL_HEALTHCHECK_URL" ]]; then
+      detail="${detail}, local_url=${LOCAL_HEALTHCHECK_URL}, local_http_code=${local_http_code:-none}, local_curl_rc=${local_curl_rc}, local_err=${local_curl_err:-none}, local_is_up=${local_is_up}"
+    fi
+    if send_discord "DOWN" "$detail"; then
       echo "$now_epoch" >"$down_alert_ts_file"
     fi
   fi


### PR DESCRIPTION
## 변경 사항\n- 외부 헬스체크 실패 시 LOCAL_HEALTHCHECK_URL로 내부 상태 재검증\n- REQUIRED_DOWN_COUNT 도입으로 연속 실패 N회일 때만 DOWN 알림 발송\n- DOWN payload에 local check 진단 필드 추가\n\n## 목적\n- Cloudflare/edge 일시 지연으로 발생하는 false positive DOWN 알림 감소\n\n## 검증\n- bash -n scripts/discord-health-alert.sh\n- 서버 시뮬레이션: 외부 실패 + 내부 정상 => health_state=UP, down_count=0