### PR TITLE
fix(main): resolve DocumentController startup conflict

### DIFF
--- a/backend/src/main/java/com/withbuddy/admin/document/controller/DocumentController.java
+++ b/backend/src/main/java/com/withbuddy/admin/document/controller/DocumentController.java
@@ -34,8 +34,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-@RestController
-@RequestMapping("/api/v1/documents")
+@RestController("adminDocumentController")
+@RequestMapping("/api/v1/admin/documents")
 @Validated
 @Tag(name = "Documents", description = "스토리지 문서 API")
 public class DocumentController {


### PR DESCRIPTION
## Summary\n- avoid Spring bean-name collision between admin and storage DocumentController\n- set admin bean name to dminDocumentController\n- move admin document route to /api/v1/admin/documents to avoid mapping overlap\n\n## Verification\n- cd backend && ./gradlew.bat compileJava ✅\n- context test currently fails on Flyway validation (FlywayValidateException), unrelated to this controller conflict