### PR TITLE
fix(main): resolve admin user endpoint mapping collision

### DIFF
--- a/backend/src/main/java/com/withbuddy/account/user/controller/UserController.java
+++ b/backend/src/main/java/com/withbuddy/account/user/controller/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/admin/users")
+@RequestMapping("/api/v1/users")
 public class UserController implements UserControllerDocs {
 
     private final UserService userService;


### PR DESCRIPTION
## Summary
- resolve startup failure from ambiguous mapping on POST /api/v1/admin/users
- move legacy UserController mapping from /api/v1/admin/users to /api/v1/users
- keep AdminUserController as the admin endpoint owner (/api/v1/admin/users)

## Verification
- cd backend && ./gradlew.bat compileJava : PASS

## Incident
- Deploy Backend run 26115250149 failed at restart with ambiguous mapping between adminUserController#createUser and userController#createUser
