### PR TITLE
feat(storage): enforce download token ttl and max-use limit

### DIFF
--- a/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheKeys.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheKeys.java
@@ -41,6 +41,10 @@ public final class RedisCacheKeys {
         return "presigned:url:" + fileId + ":" + normalize(source);
     }
 
+    public static String downloadToken(String token) {
+        return "download:token:" + token;
+    }
+
     public static String docsListFirstPage(String scope, String formType) {
         return "docs:list:" + scope + ":" + normalize(formType) + ":first";
     }

--- a/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheService.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheService.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.List;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -25,6 +26,36 @@ public class RedisCacheService {
             else
                 return 0
             end
+            """,
+            Long.class
+    );
+
+    private static final DefaultRedisScript<Long> CONSUME_DOWNLOAD_TOKEN_SCRIPT = new DefaultRedisScript<>(
+            """
+            if redis.call('exists', KEYS[1]) == 0 then
+                return -1
+            end
+
+            local documentId = redis.call('hget', KEYS[1], 'documentId')
+            local source = redis.call('hget', KEYS[1], 'source')
+            if documentId ~= ARGV[1] or source ~= ARGV[2] then
+                return -2
+            end
+
+            local remaining = tonumber(redis.call('hget', KEYS[1], 'remaining') or '-1')
+            if remaining <= 0 then
+                redis.call('del', KEYS[1])
+                return -3
+            end
+
+            remaining = remaining - 1
+            if remaining <= 0 then
+                redis.call('del', KEYS[1])
+                return 0
+            end
+
+            redis.call('hset', KEYS[1], 'remaining', tostring(remaining))
+            return remaining
             """,
             Long.class
     );
@@ -63,6 +94,21 @@ public class RedisCacheService {
 
     public void expire(String key, Duration ttl) {
         redisTemplate.expire(key, ttl);
+    }
+
+    public void putHash(String key, Map<String, String> values, Duration ttl) {
+        redisTemplate.opsForHash().putAll(key, values);
+        redisTemplate.expire(key, ttl);
+    }
+
+    public Long consumeDownloadToken(String key, String documentId, String source) {
+        Long result = redisTemplate.execute(
+                CONSUME_DOWNLOAD_TOKEN_SCRIPT,
+                Collections.singletonList(key),
+                documentId,
+                source
+        );
+        return result == null ? -1L : result;
     }
 
     public boolean releaseLock(String key, String lockValue) {

--- a/backend/src/main/java/com/withbuddy/infrastructure/storage/StorageProperties.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/storage/StorageProperties.java
@@ -16,6 +16,7 @@ public class StorageProperties {
     private int maxDocumentSizeMb = 20;
     private int maxImageSizeMb = 5;
     private int downloadUrlTtlSeconds = 300;
+    private int downloadUrlMaxUses = 1;
 
     private Bucket primary = new Bucket("primary", "withbuddy-primary");
     private Bucket backup = new Bucket("backup", "withbuddy-backup");

--- a/backend/src/main/java/com/withbuddy/storage/controller/DocumentController.java
+++ b/backend/src/main/java/com/withbuddy/storage/controller/DocumentController.java
@@ -1,0 +1,162 @@
+package com.withbuddy.storage.controller;
+
+import com.withbuddy.storage.dto.request.DocumentBulkDeleteRequest;
+import com.withbuddy.storage.dto.response.DocumentBackupRetryResponse;
+import com.withbuddy.storage.dto.response.DocumentBulkDeleteCheckResponse;
+import com.withbuddy.storage.dto.response.DocumentBulkDeleteResponse;
+import com.withbuddy.storage.dto.response.DocumentDeleteCheckResponse;
+import com.withbuddy.storage.dto.response.DocumentDeleteResponse;
+import com.withbuddy.storage.dto.response.DocumentDetailResponse;
+import com.withbuddy.storage.dto.response.DocumentDownloadResponse;
+import com.withbuddy.storage.dto.response.DocumentListResponse;
+import com.withbuddy.storage.dto.response.DocumentUploadResponse;
+import com.withbuddy.storage.entity.StorageSource;
+import com.withbuddy.storage.service.DocumentStorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/documents")
+@Validated
+@Tag(name = "Documents", description = "스토리지 문서 API")
+public class DocumentController {
+
+    private final DocumentStorageService documentStorageService;
+
+    public DocumentController(DocumentStorageService documentStorageService) {
+        this.documentStorageService = documentStorageService;
+    }
+
+    @Operation(summary = "문서 업로드")
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DocumentUploadResponse> upload(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam("title") @NotBlank String title,
+            @RequestParam("documentType") @NotBlank String documentType,
+            @RequestParam("department") @NotBlank String department,
+            @RequestParam(value = "companyCode", required = false) String companyCode
+    ) {
+        DocumentUploadResponse response = documentStorageService.upload(
+                file,
+                title,
+                documentType,
+                department,
+                companyCode
+        );
+        return ResponseEntity.status(201).body(response);
+    }
+
+    @Operation(summary = "문서 목록 조회")
+    @GetMapping
+    public ResponseEntity<DocumentListResponse> list(
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+            @RequestParam(required = false) String documentType,
+            @RequestParam(required = false) String search
+    ) {
+        return ResponseEntity.ok(documentStorageService.list(page, size, documentType, search));
+    }
+
+    @Operation(summary = "문서 상세 조회")
+    @GetMapping("/{documentId}")
+    public ResponseEntity<DocumentDetailResponse> detail(@PathVariable Long documentId) {
+        return ResponseEntity.ok(documentStorageService.getDetail(documentId));
+    }
+
+    @Operation(summary = "다운로드 URL 발급")
+    @GetMapping("/{documentId}/download")
+    public ResponseEntity<DocumentDownloadResponse> download(@PathVariable Long documentId) {
+        return ResponseEntity.ok(documentStorageService.getDownloadUrl(documentId));
+    }
+
+    @Operation(summary = "백업 재시도")
+    @PostMapping("/{documentId}/backup/retry")
+    public ResponseEntity<DocumentBackupRetryResponse> retryBackup(@PathVariable Long documentId) {
+        return ResponseEntity.ok(documentStorageService.retryBackup(documentId));
+    }
+
+    @Operation(summary = "문서 삭제")
+    @DeleteMapping("/{documentId}")
+    public ResponseEntity<DocumentDeleteResponse> delete(
+            @PathVariable Long documentId,
+            @RequestParam(defaultValue = "false") boolean confirm
+    ) {
+        return ResponseEntity.ok(documentStorageService.deleteDocument(documentId, confirm));
+    }
+
+    @Operation(summary = "문서 삭제 사전 점검")
+    @GetMapping("/{documentId}/delete-check")
+    public ResponseEntity<DocumentDeleteCheckResponse> deleteCheck(@PathVariable Long documentId) {
+        return ResponseEntity.ok(documentStorageService.getDeleteCheck(documentId));
+    }
+
+    @Operation(summary = "문서 선택 삭제 사전 점검")
+    @PostMapping("/bulk-delete/delete-check")
+    public ResponseEntity<DocumentBulkDeleteCheckResponse> bulkDeleteCheck(
+            @Valid @RequestBody DocumentBulkDeleteRequest request
+    ) {
+        return ResponseEntity.ok(documentStorageService.getBulkDeleteCheck(request));
+    }
+
+    @Operation(summary = "문서 선택 삭제 (confirm 필요)")
+    @PostMapping("/bulk-delete")
+    public ResponseEntity<DocumentBulkDeleteResponse> bulkDelete(
+            @RequestParam(defaultValue = "false") boolean confirm,
+            @Valid @RequestBody DocumentBulkDeleteRequest request
+    ) {
+        return ResponseEntity.ok(documentStorageService.bulkDeleteDocuments(request, confirm));
+    }
+
+    @Operation(summary = "문서 전체 삭제 사전 점검")
+    @GetMapping("/delete-check")
+    public ResponseEntity<DocumentBulkDeleteCheckResponse> deleteAllCheck() {
+        return ResponseEntity.ok(documentStorageService.getDeleteAllCheck());
+    }
+
+    @Operation(summary = "문서 전체 삭제 (confirm 필요)")
+    @DeleteMapping
+    public ResponseEntity<DocumentBulkDeleteResponse> deleteAll(
+            @RequestParam(defaultValue = "false") boolean confirm
+    ) {
+        return ResponseEntity.ok(documentStorageService.deleteAllDocuments(confirm));
+    }
+
+    @Operation(summary = "문서 파일 다운로드 (302 Redirect)")
+    @GetMapping("/{documentId}/file")
+    public ResponseEntity<Void> file(
+            @PathVariable Long documentId,
+            @RequestParam(defaultValue = "PRIMARY") StorageSource source,
+            @RequestParam("token") String token
+    ) {
+        String redirectUrl = documentStorageService.issueRedirectDownloadUrl(documentId, source, token);
+
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(redirectUrl))
+                .header(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, must-revalidate")
+                .header("Pragma", "no-cache")
+                .header("Referrer-Policy", "no-referrer")
+                .header("X-Content-Type-Options", "nosniff")
+                .build();
+    }
+}

--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -486,26 +486,23 @@ public class DocumentStorageService implements DocumentDownloadService {
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서 파일 메타데이터를 찾을 수 없습니다."));
 
         StorageSource source = resolveSource(file);
-        int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
-        String redisKey = RedisCacheKeys.presignedUrl(file.getId(), source.name());
-        String issuedUrl = redisCacheService.get(redisKey)
-                .filter(StringUtils::hasText)
-                .orElseGet(() -> createAndCacheDownloadUrl(documentId, file, source, redisKey, preauthTtlSeconds));
+        int tokenTtlSeconds = Math.max(1, storageProperties.getDownloadUrlTtlSeconds());
+        int tokenMaxUses = Math.max(1, storageProperties.getDownloadUrlMaxUses());
+        String downloadToken = issueDownloadToken(documentId, source, tokenTtlSeconds, tokenMaxUses);
 
-        if (StringUtils.hasText(issuedUrl) && issuedUrl.startsWith("http")) {
-            log.info(
-                    "Pre-signed download URL issued. documentId={}, source={}",
-                    documentId,
-                    source.name()
-            );
-            logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, source, preauthTtlSeconds, null, "REDIRECT");
-        }
-
-        return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source), preauthTtlSeconds, source.name());
+        return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source, downloadToken), tokenTtlSeconds, source.name());
     }
 
-    public String issueRedirectDownloadUrl(Long documentId, StorageSource source) {
+    public String issueRedirectDownloadUrl(Long documentId, StorageSource source, String downloadToken) {
         RequesterScope requesterScope = resolveDocumentAccessScope();
+        if (!StringUtils.hasText(downloadToken)) {
+            throw new StorageException(
+                    HttpStatus.BAD_REQUEST,
+                    "BAD_REQUEST",
+                    "token",
+                    "다운로드 토큰이 필요합니다."
+            );
+        }
 
         Document document = documentRepository.findByIdAndIsActiveTrue(documentId)
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서를 찾을 수 없습니다."));
@@ -522,6 +519,8 @@ public class DocumentStorageService implements DocumentDownloadService {
         if (resolvedSource == StorageSource.BACKUP && !StringUtils.hasText(file.getBackupObjectKey())) {
             throw new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "source", "백업 파일을 찾을 수 없습니다.");
         }
+
+        consumeDownloadToken(downloadToken, documentId, resolvedSource);
 
         int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
         String redisKey = RedisCacheKeys.presignedUrl(file.getId(), resolvedSource.name());
@@ -586,8 +585,46 @@ public class DocumentStorageService implements DocumentDownloadService {
         return "";
     }
 
-    private String buildInternalDownloadUrl(Long documentId, StorageSource source) {
-        return "/api/v1/documents/" + documentId + "/file?source=" + source.name();
+    private String buildInternalDownloadUrl(Long documentId, StorageSource source, String token) {
+        return "/api/v1/documents/" + documentId + "/file?source=" + source.name() + "&token=" + token;
+    }
+
+    private String issueDownloadToken(Long documentId, StorageSource source, int tokenTtlSeconds, int maxUses) {
+        String token = UUID.randomUUID().toString();
+        String tokenKey = RedisCacheKeys.downloadToken(token);
+        redisCacheService.putHash(
+                tokenKey,
+                Map.of(
+                        "documentId", String.valueOf(documentId),
+                        "source", source.name(),
+                        "remaining", String.valueOf(maxUses)
+                ),
+                Duration.ofSeconds(tokenTtlSeconds)
+        );
+        return token;
+    }
+
+    private void consumeDownloadToken(String token, Long documentId, StorageSource source) {
+        String tokenKey = RedisCacheKeys.downloadToken(token);
+        Long remaining = redisCacheService.consumeDownloadToken(tokenKey, String.valueOf(documentId), source.name());
+
+        if (remaining >= 0) {
+            return;
+        }
+        if (remaining == -2L) {
+            throw new StorageException(
+                    HttpStatus.BAD_REQUEST,
+                    "BAD_REQUEST",
+                    "token",
+                    "다운로드 토큰이 요청 대상과 일치하지 않습니다."
+            );
+        }
+        throw new StorageException(
+                HttpStatus.GONE,
+                "DOWNLOAD_TOKEN_EXPIRED",
+                "token",
+                "다운로드 토큰이 만료되었거나 사용 횟수를 초과했습니다."
+        );
     }
 
     public byte[] downloadFile(Long documentId, StorageSource source) {

--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -520,8 +520,6 @@ public class DocumentStorageService implements DocumentDownloadService {
             throw new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "source", "백업 파일을 찾을 수 없습니다.");
         }
 
-        consumeDownloadToken(downloadToken, documentId, resolvedSource);
-
         int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
         String redisKey = RedisCacheKeys.presignedUrl(file.getId(), resolvedSource.name());
         String issuedUrl = redisCacheService.get(redisKey)
@@ -537,6 +535,7 @@ public class DocumentStorageService implements DocumentDownloadService {
             );
         }
 
+        consumeDownloadToken(downloadToken, documentId, resolvedSource);
         logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, resolvedSource, preauthTtlSeconds, null, "REDIRECT");
         return issuedUrl;
     }

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -57,6 +57,7 @@ app:
     max-document-size-mb: ${STORAGE_MAX_DOCUMENT_SIZE_MB:20}
     max-image-size-mb: ${STORAGE_MAX_IMAGE_SIZE_MB:5}
     download-url-ttl-seconds: ${STORAGE_DOWNLOAD_URL_TTL_SECONDS:300}
+    download-url-max-uses: ${STORAGE_DOWNLOAD_URL_MAX_USES:1}
     retry:
       enabled: ${STORAGE_RETRY_ENABLED:true}
       max-attempts: ${STORAGE_RETRY_MAX_ATTEMPTS:5}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -93,6 +93,7 @@ app:
     max-document-size-mb: ${STORAGE_MAX_DOCUMENT_SIZE_MB:20}
     max-image-size-mb: ${STORAGE_MAX_IMAGE_SIZE_MB:5}
     download-url-ttl-seconds: ${STORAGE_DOWNLOAD_URL_TTL_SECONDS:300}
+    download-url-max-uses: ${STORAGE_DOWNLOAD_URL_MAX_USES:1}
     retry:
       enabled: ${STORAGE_RETRY_ENABLED:true}
       max-attempts: ${STORAGE_RETRY_MAX_ATTEMPTS:5}


### PR DESCRIPTION
## Summary
- enforce download URL validity by issuing Redis-backed download token with TTL
- enforce max download count per token with atomic Redis Lua decrement
- require token on /api/v1/documents/{id}/file and reject expired/exhausted tokens
- add storage config: STORAGE_DOWNLOAD_URL_MAX_USES (default 1)

## Validation
- cd backend && ./gradlew.bat compileJava : PASS

## Notes
- this PR targets develop only (no merge performed).
