### PR TITLE
feat(storage): 다운로드 토큰 TTL/횟수 제한 강제 및 차감 시점 보정

### DIFF
--- a/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheKeys.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheKeys.java
@@ -41,6 +41,10 @@ public final class RedisCacheKeys {
         return "presigned:url:" + fileId + ":" + normalize(source);
     }
 
+    public static String downloadToken(String token) {
+        return "download:token:" + token;
+    }
+
     public static String docsListFirstPage(String scope, String formType) {
         return "docs:list:" + scope + ":" + normalize(formType) + ":first";
     }

--- a/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheService.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/redis/RedisCacheService.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.List;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -25,6 +26,36 @@ public class RedisCacheService {
             else
                 return 0
             end
+            """,
+            Long.class
+    );
+
+    private static final DefaultRedisScript<Long> CONSUME_DOWNLOAD_TOKEN_SCRIPT = new DefaultRedisScript<>(
+            """
+            if redis.call('exists', KEYS[1]) == 0 then
+                return -1
+            end
+
+            local documentId = redis.call('hget', KEYS[1], 'documentId')
+            local source = redis.call('hget', KEYS[1], 'source')
+            if documentId ~= ARGV[1] or source ~= ARGV[2] then
+                return -2
+            end
+
+            local remaining = tonumber(redis.call('hget', KEYS[1], 'remaining') or '-1')
+            if remaining <= 0 then
+                redis.call('del', KEYS[1])
+                return -3
+            end
+
+            remaining = remaining - 1
+            if remaining <= 0 then
+                redis.call('del', KEYS[1])
+                return 0
+            end
+
+            redis.call('hset', KEYS[1], 'remaining', tostring(remaining))
+            return remaining
             """,
             Long.class
     );
@@ -63,6 +94,21 @@ public class RedisCacheService {
 
     public void expire(String key, Duration ttl) {
         redisTemplate.expire(key, ttl);
+    }
+
+    public void putHash(String key, Map<String, String> values, Duration ttl) {
+        redisTemplate.opsForHash().putAll(key, values);
+        redisTemplate.expire(key, ttl);
+    }
+
+    public Long consumeDownloadToken(String key, String documentId, String source) {
+        Long result = redisTemplate.execute(
+                CONSUME_DOWNLOAD_TOKEN_SCRIPT,
+                Collections.singletonList(key),
+                documentId,
+                source
+        );
+        return result == null ? -1L : result;
     }
 
     public boolean releaseLock(String key, String lockValue) {

--- a/backend/src/main/java/com/withbuddy/infrastructure/storage/StorageProperties.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/storage/StorageProperties.java
@@ -16,6 +16,7 @@ public class StorageProperties {
     private int maxDocumentSizeMb = 20;
     private int maxImageSizeMb = 5;
     private int downloadUrlTtlSeconds = 300;
+    private int downloadUrlMaxUses = 1;
 
     private Bucket primary = new Bucket("primary", "withbuddy-primary");
     private Bucket backup = new Bucket("backup", "withbuddy-backup");

--- a/backend/src/main/java/com/withbuddy/storage/controller/DocumentController.java
+++ b/backend/src/main/java/com/withbuddy/storage/controller/DocumentController.java
@@ -146,9 +146,10 @@ public class DocumentController {
     @GetMapping("/{documentId}/file")
     public ResponseEntity<Void> file(
             @PathVariable Long documentId,
-            @RequestParam(defaultValue = "PRIMARY") StorageSource source
+            @RequestParam(defaultValue = "PRIMARY") StorageSource source,
+            @RequestParam("token") String token
     ) {
-        String redirectUrl = documentStorageService.issueRedirectDownloadUrl(documentId, source);
+        String redirectUrl = documentStorageService.issueRedirectDownloadUrl(documentId, source, token);
 
         return ResponseEntity.status(HttpStatus.FOUND)
                 .location(URI.create(redirectUrl))

--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -486,26 +486,23 @@ public class DocumentStorageService implements DocumentDownloadService {
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서 파일 메타데이터를 찾을 수 없습니다."));
 
         StorageSource source = resolveSource(file);
-        int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
-        String redisKey = RedisCacheKeys.presignedUrl(file.getId(), source.name());
-        String issuedUrl = redisCacheService.get(redisKey)
-                .filter(StringUtils::hasText)
-                .orElseGet(() -> createAndCacheDownloadUrl(documentId, file, source, redisKey, preauthTtlSeconds));
+        int tokenTtlSeconds = Math.max(1, storageProperties.getDownloadUrlTtlSeconds());
+        int tokenMaxUses = Math.max(1, storageProperties.getDownloadUrlMaxUses());
+        String downloadToken = issueDownloadToken(documentId, source, tokenTtlSeconds, tokenMaxUses);
 
-        if (StringUtils.hasText(issuedUrl) && issuedUrl.startsWith("http")) {
-            log.info(
-                    "Pre-signed download URL issued. documentId={}, source={}",
-                    documentId,
-                    source.name()
-            );
-            logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, source, preauthTtlSeconds, null, "REDIRECT");
-        }
-
-        return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source), preauthTtlSeconds, source.name());
+        return new DocumentDownloadResponse(buildInternalDownloadUrl(documentId, source, downloadToken), tokenTtlSeconds, source.name());
     }
 
-    public String issueRedirectDownloadUrl(Long documentId, StorageSource source) {
+    public String issueRedirectDownloadUrl(Long documentId, StorageSource source, String downloadToken) {
         RequesterScope requesterScope = resolveDocumentAccessScope();
+        if (!StringUtils.hasText(downloadToken)) {
+            throw new StorageException(
+                    HttpStatus.BAD_REQUEST,
+                    "BAD_REQUEST",
+                    "token",
+                    "다운로드 토큰이 필요합니다."
+            );
+        }
 
         Document document = documentRepository.findByIdAndIsActiveTrue(documentId)
                 .orElseThrow(() -> new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서를 찾을 수 없습니다."));
@@ -522,6 +519,8 @@ public class DocumentStorageService implements DocumentDownloadService {
         if (resolvedSource == StorageSource.BACKUP && !StringUtils.hasText(file.getBackupObjectKey())) {
             throw new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "source", "백업 파일을 찾을 수 없습니다.");
         }
+
+        consumeDownloadToken(downloadToken, documentId, resolvedSource);
 
         int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
         String redisKey = RedisCacheKeys.presignedUrl(file.getId(), resolvedSource.name());
@@ -586,8 +585,46 @@ public class DocumentStorageService implements DocumentDownloadService {
         return "";
     }
 
-    private String buildInternalDownloadUrl(Long documentId, StorageSource source) {
-        return "/api/v1/documents/" + documentId + "/file?source=" + source.name();
+    private String buildInternalDownloadUrl(Long documentId, StorageSource source, String token) {
+        return "/api/v1/documents/" + documentId + "/file?source=" + source.name() + "&token=" + token;
+    }
+
+    private String issueDownloadToken(Long documentId, StorageSource source, int tokenTtlSeconds, int maxUses) {
+        String token = UUID.randomUUID().toString();
+        String tokenKey = RedisCacheKeys.downloadToken(token);
+        redisCacheService.putHash(
+                tokenKey,
+                Map.of(
+                        "documentId", String.valueOf(documentId),
+                        "source", source.name(),
+                        "remaining", String.valueOf(maxUses)
+                ),
+                Duration.ofSeconds(tokenTtlSeconds)
+        );
+        return token;
+    }
+
+    private void consumeDownloadToken(String token, Long documentId, StorageSource source) {
+        String tokenKey = RedisCacheKeys.downloadToken(token);
+        Long remaining = redisCacheService.consumeDownloadToken(tokenKey, String.valueOf(documentId), source.name());
+
+        if (remaining >= 0) {
+            return;
+        }
+        if (remaining == -2L) {
+            throw new StorageException(
+                    HttpStatus.BAD_REQUEST,
+                    "BAD_REQUEST",
+                    "token",
+                    "다운로드 토큰이 요청 대상과 일치하지 않습니다."
+            );
+        }
+        throw new StorageException(
+                HttpStatus.GONE,
+                "DOWNLOAD_TOKEN_EXPIRED",
+                "token",
+                "다운로드 토큰이 만료되었거나 사용 횟수를 초과했습니다."
+        );
     }
 
     public byte[] downloadFile(Long documentId, StorageSource source) {

--- a/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
+++ b/backend/src/main/java/com/withbuddy/storage/service/DocumentStorageService.java
@@ -520,8 +520,6 @@ public class DocumentStorageService implements DocumentDownloadService {
             throw new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "source", "백업 파일을 찾을 수 없습니다.");
         }
 
-        consumeDownloadToken(downloadToken, documentId, resolvedSource);
-
         int preauthTtlSeconds = Math.max(1, storageProperties.getOciCli().getPreauthTtlSeconds());
         String redisKey = RedisCacheKeys.presignedUrl(file.getId(), resolvedSource.name());
         String issuedUrl = redisCacheService.get(redisKey)
@@ -537,6 +535,7 @@ public class DocumentStorageService implements DocumentDownloadService {
             );
         }
 
+        consumeDownloadToken(downloadToken, documentId, resolvedSource);
         logDownloadAuditEvent("DOWNLOAD_URL_ISSUED", requesterScope, document, resolvedSource, preauthTtlSeconds, null, "REDIRECT");
         return issuedUrl;
     }

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -57,6 +57,7 @@ app:
     max-document-size-mb: ${STORAGE_MAX_DOCUMENT_SIZE_MB:20}
     max-image-size-mb: ${STORAGE_MAX_IMAGE_SIZE_MB:5}
     download-url-ttl-seconds: ${STORAGE_DOWNLOAD_URL_TTL_SECONDS:300}
+    download-url-max-uses: ${STORAGE_DOWNLOAD_URL_MAX_USES:1}
     retry:
       enabled: ${STORAGE_RETRY_ENABLED:true}
       max-attempts: ${STORAGE_RETRY_MAX_ATTEMPTS:5}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -93,6 +93,7 @@ app:
     max-document-size-mb: ${STORAGE_MAX_DOCUMENT_SIZE_MB:20}
     max-image-size-mb: ${STORAGE_MAX_IMAGE_SIZE_MB:5}
     download-url-ttl-seconds: ${STORAGE_DOWNLOAD_URL_TTL_SECONDS:300}
+    download-url-max-uses: ${STORAGE_DOWNLOAD_URL_MAX_USES:1}
     retry:
       enabled: ${STORAGE_RETRY_ENABLED:true}
       max-attempts: ${STORAGE_RETRY_MAX_ATTEMPTS:5}


### PR DESCRIPTION
## 작업 내용
- 다운로드 토큰에 만료 시간(TTL)과 허용 횟수(max uses) 검증을 강제했습니다.
- Redirect URL 발급 성공 전에 토큰이 차감되던 동작을 수정했습니다.
- URL 발급 성공 이후에만 토큰을 차감하도록 순서를 보정했습니다.

## 기대 효과
- 허용 시간/허용 횟수 정책이 토큰 단위로 강제됩니다.
- 일시적인 스토리지/캐시 장애 시 토큰이 불필요하게 소진되는 문제를 방지합니다.

## 검증
- ackend: ./gradlew.bat compileJava 성공
