### PR TITLE
fix: address SCRUM-324 PR review issues

### DIFF
--- a/backend/src/main/java/com/withbuddy/global/security/InternalApiAuthenticationFilter.java
+++ b/backend/src/main/java/com/withbuddy/global/security/InternalApiAuthenticationFilter.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class InternalApiAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String INTERNAL_API_PREFIX = "/internal/v1/";
+    private static final String MESSAGING_API_PREFIX = "/api/v1/messaging/";
     private static final String INTERNAL_ROLE = "ROLE_INTERNAL_API";
 
     private final InternalApiSecurityProperties properties;
@@ -43,7 +44,8 @@ public class InternalApiAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return !request.getRequestURI().startsWith(INTERNAL_API_PREFIX);
+        String uri = request.getRequestURI();
+        return !uri.startsWith(INTERNAL_API_PREFIX) && !uri.startsWith(MESSAGING_API_PREFIX);
     }
 
     @Override

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/RabbitMqConfig.java
@@ -50,7 +50,7 @@ public class RabbitMqConfig {
     public Queue internalTasksQueue(AppRabbitMqProperties properties) {
         return QueueBuilder.durable(properties.queueInternalTasks())
                 .withArgument("x-dead-letter-exchange", properties.exchange())
-                .withArgument("x-dead-letter-routing-key", "internal.tasks.dlq")
+                .withArgument("x-dead-letter-routing-key", "dlq.internal.tasks")
                 .build();
     }
 
@@ -83,7 +83,7 @@ public class RabbitMqConfig {
         Binding internalTasksDlqBinding = BindingBuilder
                 .bind(internalTasksDlqQueue)
                 .to(appExchange)
-                .with("internal.tasks.dlq");
+                .with("dlq.internal.tasks");
 
         return new Declarables(
                 nudgeBinding,

--- a/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/InternalTaskAiNudgeAnalysisHandler.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/mq/consumer/InternalTaskAiNudgeAnalysisHandler.java
@@ -47,6 +47,7 @@ public class InternalTaskAiNudgeAnalysisHandler implements InternalTaskHandler {
             result.put("callbackSent", false);
             return result;
         }
+        String callbackUrl = message.callbackUrl().trim();
 
         ObjectNode callbackBody = objectMapper.createObjectNode();
         callbackBody.put("event", "TASK_COMPLETED");
@@ -58,7 +59,7 @@ public class InternalTaskAiNudgeAnalysisHandler implements InternalTaskHandler {
         try {
             String rawBody = objectMapper.writeValueAsString(callbackBody);
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(message.callbackUrl()))
+                    .uri(URI.create(callbackUrl))
                     .timeout(Duration.ofSeconds(resolveTimeoutSeconds(message.timeoutSeconds())))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(rawBody))


### PR DESCRIPTION
  1. DLQ 라우팅 키 충돌 방지

  - internal.tasks.dlq → dlq.internal.tasks로 변경
  - live 큐 바인딩(internal.tasks.#)과 겹치지 않게 분리

  2. 내부 API 인증 경로 확장

  - InternalApiAuthenticationFilter 적용 대상을
    /internal/v1/** + /api/v1/messaging/**로 확장
  - /api/v1/messaging/** 403 문제 해결

  3. callback URL 정규화

  - URI.create(message.callbackUrl()) 전에 trim() 적용
  - 공백 포함 URL로 인한 불필요한 실패/DLQ 적재 방지