### PR TITLE
fix: split 404 code handling for route and resource

### DIFF
--- a/backend/src/main/java/com/withbuddy/global/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/withbuddy/global/dto/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.withbuddy.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -19,6 +20,7 @@ public class ErrorResponse {
     private final String error;
 
     @Schema(description = "에러 코드", example = "UNAUTHORIZED")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String code;
 
     @Schema(description = "에러 메시지", example = "입력하신 정보를 다시 확인해 주세요")

--- a/backend/src/main/java/com/withbuddy/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/withbuddy/global/exception/GlobalExceptionHandler.java
@@ -27,6 +27,8 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -358,6 +360,29 @@ public class GlobalExceptionHandler {
         RedisFailureLogSupport.logRedisFailure(log, request, e);
 
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
+    }
+
+    @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+    public ResponseEntity<ErrorResponse> handleNotFoundException(
+            Exception e,
+            HttpServletRequest request
+    ) {
+        List<FieldValidationError> errors = List.of(
+                new FieldValidationError("path", "요청한 경로를 찾을 수 없습니다.")
+        );
+
+        ErrorResponse response = new ErrorResponse(
+                OffsetDateTime.now(ZoneOffset.UTC).toString(),
+                HttpStatus.NOT_FOUND.value(),
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                null,
+                errors,
+                resolveMaskedPath(request)
+        );
+
+        log.warn("Not found: path={}, message={}", resolveMaskedPath(request), e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/com/withbuddy/global/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/withbuddy/global/exception/GlobalExceptionHandlerTest.java
@@ -1,11 +1,14 @@
 package com.withbuddy.global.exception;
 
 import com.withbuddy.global.dto.ErrorResponse;
+import com.withbuddy.storage.exception.StorageException;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,5 +31,41 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getPath()).isEqualTo("/api/v1/auth/logout");
         assertThat(response.getBody().getErrors()).isNotEmpty();
         assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("server");
+    }
+
+    @Test
+    void omitsCodeForRouteMissing404() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/not/exist");
+
+        ResponseEntity<ErrorResponse> response = handler.handleNotFoundException(
+                new NoResourceFoundException(HttpMethod.GET, "/not/exist"),
+                request
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getCode()).isNull();
+        assertThat(response.getBody().getPath()).isEqualTo("/not/exist");
+        assertThat(response.getBody().getErrors()).isNotEmpty();
+        assertThat(response.getBody().getErrors().get(0).getField()).isEqualTo("path");
+    }
+
+    @Test
+    void keepsNotFoundCodeForResourceMissing404() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/documents/100");
+
+        ResponseEntity<ErrorResponse> response = handler.handleStorageException(
+                new StorageException(HttpStatus.NOT_FOUND, "NOT_FOUND", "documentId", "문서를 찾을 수 없습니다."),
+                request
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(404);
+        assertThat(response.getBody().getCode()).isEqualTo("NOT_FOUND");
+        assertThat(response.getBody().getPath()).isEqualTo("/api/v1/documents/100");
     }
 }


### PR DESCRIPTION
404 code 없음 (라우트 누락) → 공통 토스트 + 로깅
404 NOT_FOUND (리소스 없음) → 맥락 메시지