### PR TITLE
fix(ai): Cache API 스펙 정합 및 /chat/stream 이벤트 필드 추가

### DIFF
--- a/ai/core/be_client.py
+++ b/ai/core/be_client.py
@@ -73,11 +73,18 @@ def _call(method: str, path: str, *, json_body=None, timeout: float = 2.0, max_r
 
 # ── Cache API ────────────────────────────────────────────────
 
+def _safe_key(key: str, max_len: int = 190) -> str:
+    """key가 max_len 초과 시 SHA256 해시로 대체 (BE maxLength: 200)."""
+    if len(key) <= max_len:
+        return key
+    return hashlib.sha256(key.encode()).hexdigest()[:64]
+
+
 def cache_get(namespace: str, key: str):
     """캐시 단일 조회. 없으면 None 반환."""
     try:
         r = _call("POST", "/internal/v1/cache/get",
-                  json_body={"key": f"{namespace}:{key}"})
+                  json_body={"namespace": namespace, "key": _safe_key(key)})
         data = r.json()
         return data.get("value") if data.get("found") else None
     except Exception as e:
@@ -88,12 +95,11 @@ def cache_get(namespace: str, key: str):
 def cache_get_multi(namespace: str, keys: list) -> dict:
     """캐시 다중 조회. {key: value} 형태로 반환 (found인 것만 포함)."""
     try:
-        prefixed = [f"{namespace}:{k}" for k in keys]
+        key_map = {_safe_key(k): k for k in keys}
         r = _call("POST", "/internal/v1/cache/get-multi",
-                  json_body={"keys": prefixed})
+                  json_body={"namespace": namespace, "keys": list(key_map.keys())})
         items = r.json().get("items", [])
-        prefix = f"{namespace}:"
-        return {item["key"].removeprefix(prefix): item["value"] for item in items if item.get("found")}
+        return {key_map[item["key"]]: item["value"] for item in items if item.get("found") and item["key"] in key_map}
     except Exception as e:
         logger.warning("cache_get_multi 실패 (%s): %s", namespace, e)
         return {}
@@ -103,7 +109,7 @@ def cache_set(namespace: str, key: str, value, ttl_seconds: int = 300) -> bool:
     """캐시 단일 저장. 실패 시 False 반환."""
     try:
         _call("POST", "/internal/v1/cache/set",
-              json_body={"key": f"{namespace}:{key}", "value": value, "ttlSeconds": ttl_seconds})
+              json_body={"namespace": namespace, "key": _safe_key(key), "value": value, "ttlSeconds": ttl_seconds})
         return True
     except Exception as e:
         logger.warning("cache_set 실패 (%s:%s): %s", namespace, key, e)
@@ -116,9 +122,9 @@ def cache_set_multi(namespace: str, items: list[dict], ttl_seconds: int = 300) -
     반환: {"ok": bool, "written": int, "errors": [...]}
     """
     try:
-        payload = [{"key": f"{namespace}:{i['key']}", "value": i["value"], "ttlSeconds": ttl_seconds} for i in items]
+        payload = [{"key": _safe_key(i['key']), "value": i["value"]} for i in items]
         r = _call("POST", "/internal/v1/cache/set-multi",
-                  json_body={"items": payload})
+                  json_body={"namespace": namespace, "items": payload, "ttlSeconds": ttl_seconds})
         data = r.json()
         if not data.get("ok") and data.get("errors"):
             for err in data["errors"]:
@@ -133,7 +139,7 @@ def cache_del(namespace: str, key: str) -> bool:
     """캐시 삭제."""
     try:
         _call("POST", "/internal/v1/cache/del",
-              json_body={"key": f"{namespace}:{key}"})
+              json_body={"namespace": namespace, "key": _safe_key(key)})
         return True
     except Exception as e:
         logger.warning("cache_del 실패 (%s:%s): %s", namespace, key, e)

--- a/ai/routers/chat.py
+++ b/ai/routers/chat.py
@@ -16,7 +16,6 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
-from agents.orchestrator import run_orchestrator
 from chains.rag_chain import run_rag_chain, stream_rag_chain
 from core.llm import get_llm
 from memory.chat_history import clear_memory, get_chat_history, get_history_as_text, save_interaction
@@ -96,12 +95,20 @@ async def chat_stream(request: ChatRequest):
     """
     async def event_generator():
         try:
-            from chains.rag_chain import _fix_names
+            from agents.orchestrator import run_orchestrator
+            from chains.rag_chain import _fix_names, pop_token_usage, pop_category
             from chains.retriever import resolve_selection as _resolve_selection
             from memory.chat_history import get_chat_history as _get_history
-            # 2-7: 숫자 선택("1"~"4")을 이전 ambiguous 응답과 매핑
+
             uid = str(request.user.userId)
             message = request.content
+
+            # 욕설·극단적 위기 전체 차단
+            action, block_answer = check_global_block(message, request.user.name)
+            if action == "block":
+                yield f"event: answer_completed\ndata: {json.dumps({'questionId': request.questionId, 'messageType': 'out_of_scope', 'content': block_answer, 'documents': [], 'recommendedContacts': []}, ensure_ascii=False)}\n\n"
+                return
+
             resolved = _resolve_selection(message, _get_history(uid))
             if resolved:
                 message = resolved
@@ -110,8 +117,9 @@ async def chat_stream(request: ChatRequest):
             if result.intent != "rag":
                 fixed_answer = _fix_names(result.answer)
                 save_interaction(uid, message, fixed_answer)
+                msg_type = result.intent if result.intent in ("sensitive", "out_of_scope") else "out_of_scope"
                 yield f"event: answer_delta\ndata: {json.dumps({'questionId': request.questionId, 'content': fixed_answer}, ensure_ascii=False)}\n\n"
-                yield f"event: answer_completed\ndata: {json.dumps({'questionId': request.questionId, 'messageType': 'out_of_scope', 'content': fixed_answer, 'documents': [], 'recommendedContacts': []}, ensure_ascii=False)}\n\n"
+                yield f"event: answer_completed\ndata: {json.dumps({'questionId': request.questionId, 'messageType': msg_type, 'content': fixed_answer, 'documents': [], 'recommendedContacts': []}, ensure_ascii=False)}\n\n"
                 return
 
             accumulated_text: list[str] = []
@@ -132,9 +140,10 @@ async def chat_stream(request: ChatRequest):
                         contact = await get_contact_for_question(request.user.companyCode, request.content)
                         contacts = [contact]
                     doc_ids = [{"documentId": did} for did in (rag_doc_ids or [])][:2]
-                    yield f"event: answer_completed\ndata: {json.dumps({'questionId': request.questionId, 'messageType': msg_type, 'content': full_answer, 'documents': doc_ids, 'recommendedContacts': contacts}, ensure_ascii=False)}\n\n"
+                    tok = pop_token_usage()
+                    yield f"event: answer_completed\ndata: {json.dumps({'questionId': request.questionId, 'messageType': msg_type, 'content': full_answer, 'documents': doc_ids, 'recommendedContacts': contacts, 'inputTokens': tok['input_tokens'], 'outputTokens': tok['output_tokens'], 'cacheReadTokens': tok['cache_read'], 'cacheCreationTokens': tok['cache_creation'], 'latencyMs': 0, 'category': pop_category()}, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, str) and chunk.startswith("__STAGE__"):
-                    pass  # 내부 스테이지 마커는 클라이언트에 전달하지 않음
+                    pass
                 elif isinstance(chunk, str) and chunk.startswith("\x00"):
                     accumulated_text.clear()
                     accumulated_text.append(chunk[1:])


### PR DESCRIPTION
<!-- AUTO_FILL_COMMITS_START -->
## 변경 사항
- fix(ai): Cache API 스펙 정합 및 /chat/stream 이벤트 필드 추가
<!-- AUTO_FILL_COMMITS_END -->

- be_client: Cache API namespace/key 필드 분리 (400 오류 수정)
- be_client: cache_set_multi ttlSeconds 위치 수정 (item→요청 최상위)
- be_client: _safe_key() 추가 (key 190자 초과 시 SHA256 해시)
- chat.py: /chat/stream global_block 체크 추가
- chat.py: sensitive intent messageType 정확히 구분
- chat.py: answer_completed에 token 사용량·category 필드 추가

<!-- AUTO_FILL_TEMPLATE -->
PR 요약은 자동으로 생성됩니다. 제목만 적어주세요.

## 추가 요약(선택)
- 자동 생성만으로 부족할 때만 작성해주세요.
- 배경/의사결정/리스크를 1~3줄로 적어주세요.

## 리뷰 포인트(선택)
- 리뷰어가 특히 봐야 할 부분이 있으면 작성해주세요.