### PR TITLE
Release/caching layer 02

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -49,6 +49,36 @@ jobs:
           fi
           cp "${JAR_PATH}" app.jar
 
+      - name: Calculate Flyway checksum for V19 migration
+        id: v19_checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > /tmp/FlywayChecksumV19.java <<'JAVA'
+          import java.nio.charset.StandardCharsets;
+          import java.nio.file.Files;
+          import java.nio.file.Path;
+          import java.util.List;
+          import java.util.zip.CRC32;
+
+          public class FlywayChecksumV19 {
+              public static void main(String[] args) throws Exception {
+                  Path path = Path.of("backend/src/main/resources/db/migration/V19__dedupe_and_add_unique_for_suggestion_messages.sql");
+                  List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+                  if (!lines.isEmpty() && !lines.get(0).isEmpty() && lines.get(0).charAt(0) == '\uFEFF') {
+                      lines.set(0, lines.get(0).substring(1));
+                  }
+                  CRC32 crc = new CRC32();
+                  for (String line : lines) {
+                      crc.update(line.getBytes(StandardCharsets.UTF_8));
+                  }
+                  System.out.println((int) crc.getValue());
+              }
+          }
+          JAVA
+          CHECKSUM="$(java /tmp/FlywayChecksumV19.java)"
+          echo "value=${CHECKSUM}" >> "$GITHUB_OUTPUT"
+          echo "Computed Flyway-style checksum for V19 migration: ${CHECKSUM}"
       - name: Validate required environment secrets
         env:
           BACKEND_ACCESS_HOST: ${{ secrets.BACKEND_ACCESS_HOST }}

--- a/backend/src/main/java/com/withbuddy/infrastructure/cache/AppCacheProperties.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/cache/AppCacheProperties.java
@@ -17,12 +17,16 @@ public class AppCacheProperties {
     private L1 l1 = new L1();
     private L2 l2 = new L2();
     private Codec codec = new Codec();
+    private Invalidation invalidation = new Invalidation();
 
     @Getter
     @Setter
     public static class L1 {
         private boolean enabled = true;
         private String spec = "maximumSize=5000,expireAfterWrite=10m,recordStats";
+        private int negativeTtlSeconds = 30;
+        private boolean swrEnabled = true;
+        private int swrRefreshAfterSeconds = 15;
     }
 
     @Getter
@@ -40,5 +44,13 @@ public class AppCacheProperties {
         private boolean compressionEnabled = true;
         private int compressionThresholdBytes = 1024;
         private String format = "msgpack";
+    }
+
+    @Getter
+    @Setter
+    public static class Invalidation {
+        private boolean enabled = true;
+        private String channel = "withbuddy:cache:invalidate";
+        private String nodeId = "";
     }
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/cache/CacheInvalidationPublisher.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/cache/CacheInvalidationPublisher.java
@@ -1,0 +1,35 @@
+package com.withbuddy.infrastructure.cache;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@Component
+public class CacheInvalidationPublisher {
+
+    private final StringRedisTemplate redisTemplate;
+    private final AppCacheProperties properties;
+    private final String nodeId;
+
+    public CacheInvalidationPublisher(StringRedisTemplate redisTemplate, AppCacheProperties properties) {
+        this.redisTemplate = redisTemplate;
+        this.properties = properties;
+        this.nodeId = StringUtils.hasText(properties.getInvalidation().getNodeId())
+                ? properties.getInvalidation().getNodeId().trim()
+                : UUID.randomUUID().toString();
+    }
+
+    public String nodeId() {
+        return nodeId;
+    }
+
+    public void publishKeyInvalidation(String cacheKey) {
+        if (!properties.getInvalidation().isEnabled()) {
+            return;
+        }
+        String payload = nodeId + "|" + cacheKey;
+        redisTemplate.convertAndSend(properties.getInvalidation().getChannel(), payload);
+    }
+}

--- a/backend/src/main/java/com/withbuddy/infrastructure/cache/CacheLayerConfig.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/cache/CacheLayerConfig.java
@@ -1,11 +1,19 @@
 package com.withbuddy.infrastructure.cache;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import java.nio.charset.StandardCharsets;
 
 @Configuration
 @EnableCaching
@@ -20,5 +28,46 @@ public class CacheLayerConfig {
             manager.setCaffeine(Caffeine.newBuilder().maximumSize(1));
         }
         return manager;
+    }
+
+    @Bean("internalApiLocalCache")
+    public Cache<String, InternalApiLocalCacheValue> internalApiLocalCache(AppCacheProperties properties) {
+        return Caffeine.from(properties.getL1().getSpec()).build();
+    }
+
+    @Bean
+    public RedisMessageListenerContainer cacheInvalidationListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            AppCacheProperties properties,
+            CacheInvalidationPublisher publisher,
+            Cache<String, InternalApiLocalCacheValue> internalApiLocalCache
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        if (!properties.getInvalidation().isEnabled()) {
+            return container;
+        }
+
+        MessageListener listener = (Message message, byte[] pattern) -> {
+            String payload = new String(message.getBody(), StandardCharsets.UTF_8);
+            int sep = payload.indexOf('|');
+            if (sep < 0) {
+                return;
+            }
+
+            String sender = payload.substring(0, sep);
+            if (publisher.nodeId().equals(sender)) {
+                return;
+            }
+
+            String cacheKey = payload.substring(sep + 1);
+            if (!cacheKey.isBlank()) {
+                internalApiLocalCache.invalidate(cacheKey);
+            }
+        };
+
+        container.addMessageListener(listener, new ChannelTopic(properties.getInvalidation().getChannel()));
+        return container;
     }
 }

--- a/backend/src/main/java/com/withbuddy/infrastructure/cache/InternalApiLocalCacheValue.java
+++ b/backend/src/main/java/com/withbuddy/infrastructure/cache/InternalApiLocalCacheValue.java
@@ -1,0 +1,25 @@
+package com.withbuddy.infrastructure.cache;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record InternalApiLocalCacheValue(
+        boolean found,
+        JsonNode value,
+        long loadedAtEpochMillis
+) {
+
+    public static InternalApiLocalCacheValue hit(JsonNode value) {
+        return new InternalApiLocalCacheValue(true, value, System.currentTimeMillis());
+    }
+
+    public static InternalApiLocalCacheValue miss() {
+        return new InternalApiLocalCacheValue(false, null, System.currentTimeMillis());
+    }
+
+    public boolean isNegativeExpired(long nowEpochMillis, long negativeTtlMillis) {
+        if (found) {
+            return false;
+        }
+        return nowEpochMillis - loadedAtEpochMillis >= negativeTtlMillis;
+    }
+}

--- a/backend/src/main/java/com/withbuddy/internal/api/InternalCacheApiService.java
+++ b/backend/src/main/java/com/withbuddy/internal/api/InternalCacheApiService.java
@@ -1,16 +1,24 @@
 package com.withbuddy.internal.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.withbuddy.infrastructure.cache.AppCacheProperties;
+import com.withbuddy.infrastructure.cache.CacheInvalidationPublisher;
 import com.withbuddy.infrastructure.cache.CacheKeyBuilder;
 import com.withbuddy.infrastructure.cache.CachePayloadCodec;
 import com.withbuddy.infrastructure.cache.CacheTtlPolicy;
+import com.withbuddy.infrastructure.cache.InternalApiLocalCacheValue;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.withbuddy.internal.api.InternalApiModels.CacheDeleteRequest;
 import static com.withbuddy.internal.api.InternalApiModels.CacheGetMultiRequest;
@@ -30,17 +38,20 @@ public class InternalCacheApiService {
     private static final String DEFAULT_NAMESPACE = "default";
 
     private final StringRedisTemplate redisTemplate;
+    private final AppCacheProperties cacheProperties;
     private final CacheKeyBuilder cacheKeyBuilder;
     private final CachePayloadCodec cachePayloadCodec;
     private final CacheTtlPolicy cacheTtlPolicy;
+    private final CacheInvalidationPublisher cacheInvalidationPublisher;
+    @Qualifier("internalApiLocalCache")
+    private final Cache<String, InternalApiLocalCacheValue> internalApiLocalCache;
+    private final Set<String> swrRefreshInFlight = ConcurrentHashMap.newKeySet();
 
     public CacheGetResponse get(CacheGetRequest request) {
         String namespace = normalizeNamespace(request.namespace());
         String resolvedKey = buildRedisKey(namespace, request.key());
-        String raw = redisTemplate.opsForValue().get(resolvedKey);
-        boolean found = raw != null;
-        JsonNode value = found ? cachePayloadCodec.decode(raw) : null;
-        return new CacheGetResponse(request.key(), namespace, found, value);
+        InternalApiLocalCacheValue cached = resolveLocalValue(resolvedKey);
+        return new CacheGetResponse(request.key(), namespace, cached.found(), cached.value());
     }
 
     public CacheGetMultiResponse getMulti(CacheGetMultiRequest request) {
@@ -49,14 +60,12 @@ public class InternalCacheApiService {
         List<String> resolvedKeys = originalKeys.stream()
                 .map(key -> buildRedisKey(namespace, key))
                 .toList();
-        List<String> values = redisTemplate.opsForValue().multiGet(resolvedKeys);
 
         List<CacheGetResponse> items = new ArrayList<>();
         for (int i = 0; i < originalKeys.size(); i++) {
-            String raw = values != null && i < values.size() ? values.get(i) : null;
-            boolean found = raw != null;
-            JsonNode value = found ? cachePayloadCodec.decode(raw) : null;
-            items.add(new CacheGetResponse(originalKeys.get(i), namespace, found, value));
+            String resolvedKey = resolvedKeys.get(i);
+            InternalApiLocalCacheValue cached = resolveLocalValue(resolvedKey);
+            items.add(new CacheGetResponse(originalKeys.get(i), namespace, cached.found(), cached.value()));
         }
         return new CacheGetMultiResponse(namespace, items);
     }
@@ -66,6 +75,8 @@ public class InternalCacheApiService {
         String resolvedKey = buildRedisKey(namespace, request.key());
         String encoded = cachePayloadCodec.encode(request.value());
         redisTemplate.opsForValue().set(resolvedKey, encoded, cacheTtlPolicy.resolve(request.ttlSeconds()));
+        internalApiLocalCache.put(resolvedKey, InternalApiLocalCacheValue.hit(request.value()));
+        cacheInvalidationPublisher.publishKeyInvalidation(resolvedKey);
         return new CacheWriteResponse(namespace, 1);
     }
 
@@ -86,6 +97,8 @@ public class InternalCacheApiService {
             try {
                 String encoded = cachePayloadCodec.encode(item.value());
                 redisTemplate.opsForValue().set(resolvedKey, encoded, ttl);
+                internalApiLocalCache.put(resolvedKey, InternalApiLocalCacheValue.hit(item.value()));
+                cacheInvalidationPublisher.publishKeyInvalidation(resolvedKey);
                 written += 1;
             } catch (RuntimeException ex) {
                 errors.add(new CacheSetMultiError(item.key(), ex.getMessage()));
@@ -98,7 +111,59 @@ public class InternalCacheApiService {
         String namespace = normalizeNamespace(request.namespace());
         String resolvedKey = buildRedisKey(namespace, request.key());
         Boolean deleted = redisTemplate.delete(resolvedKey);
+        internalApiLocalCache.invalidate(resolvedKey);
+        cacheInvalidationPublisher.publishKeyInvalidation(resolvedKey);
         return new CacheWriteResponse(namespace, Boolean.TRUE.equals(deleted) ? 1 : 0);
+    }
+
+    private InternalApiLocalCacheValue resolveLocalValue(String resolvedKey) {
+        long now = System.currentTimeMillis();
+        long negativeTtlMillis = Math.max(1, cacheProperties.getL1().getNegativeTtlSeconds()) * 1000L;
+
+        InternalApiLocalCacheValue cached = internalApiLocalCache.getIfPresent(resolvedKey);
+        if (cached != null && !cached.isNegativeExpired(now, negativeTtlMillis)) {
+            triggerSWRIfNeeded(resolvedKey, cached, now);
+            return cached;
+        }
+        if (cached != null) {
+            internalApiLocalCache.invalidate(resolvedKey);
+        }
+        return internalApiLocalCache.get(resolvedKey, this::loadFromRedis);
+    }
+
+    private InternalApiLocalCacheValue loadFromRedis(String resolvedKey) {
+        String raw = redisTemplate.opsForValue().get(resolvedKey);
+        if (raw == null) {
+            return InternalApiLocalCacheValue.miss();
+        }
+        JsonNode decoded = cachePayloadCodec.decode(raw);
+        return InternalApiLocalCacheValue.hit(decoded);
+    }
+
+    private void triggerSWRIfNeeded(String resolvedKey, InternalApiLocalCacheValue cached, long now) {
+        if (!cached.found() || !cacheProperties.getL1().isSwrEnabled()) {
+            return;
+        }
+
+        long refreshAfterMillis = Math.max(1, cacheProperties.getL1().getSwrRefreshAfterSeconds()) * 1000L;
+        if (now - cached.loadedAtEpochMillis() < refreshAfterMillis) {
+            return;
+        }
+
+        if (!swrRefreshInFlight.add(resolvedKey)) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                InternalApiLocalCacheValue refreshed = loadFromRedis(resolvedKey);
+                internalApiLocalCache.put(resolvedKey, refreshed);
+            } catch (RuntimeException ignored) {
+                // SWR refresh 실패는 요청 흐름에 영향 주지 않는다.
+            } finally {
+                swrRefreshInFlight.remove(resolvedKey);
+            }
+        });
     }
 
     private String normalizeNamespace(String namespace) {

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -41,6 +41,9 @@ app:
     l1:
       enabled: ${APP_CACHE_L1_ENABLED:true}
       spec: ${APP_CACHE_L1_SPEC:maximumSize=10000,expireAfterWrite=15m,recordStats}
+      negative-ttl-seconds: ${APP_CACHE_L1_NEGATIVE_TTL_SECONDS:30}
+      swr-enabled: ${APP_CACHE_L1_SWR_ENABLED:true}
+      swr-refresh-after-seconds: ${APP_CACHE_L1_SWR_REFRESH_AFTER_SECONDS:15}
     l2:
       default-ttl-seconds: ${APP_CACHE_L2_DEFAULT_TTL_SECONDS:300}
       min-ttl-seconds: ${APP_CACHE_L2_MIN_TTL_SECONDS:5}
@@ -50,6 +53,10 @@ app:
       compression-enabled: ${APP_CACHE_CODEC_COMPRESSION_ENABLED:true}
       compression-threshold-bytes: ${APP_CACHE_CODEC_COMPRESSION_THRESHOLD_BYTES:1024}
       format: ${APP_CACHE_CODEC_FORMAT:msgpack}
+    invalidation:
+      enabled: ${APP_CACHE_INVALIDATION_ENABLED:true}
+      channel: ${APP_CACHE_INVALIDATION_CHANNEL:withbuddy:cache:invalidate}
+      node-id: ${APP_CACHE_INVALIDATION_NODE_ID:}
   security:
     storage-api:
       enabled: ${STORAGE_API_AUTH_ENABLED:true}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -61,6 +61,9 @@ app:
     l1:
       enabled: ${APP_CACHE_L1_ENABLED:true}
       spec: ${APP_CACHE_L1_SPEC:maximumSize=5000,expireAfterWrite=10m,recordStats}
+      negative-ttl-seconds: ${APP_CACHE_L1_NEGATIVE_TTL_SECONDS:30}
+      swr-enabled: ${APP_CACHE_L1_SWR_ENABLED:true}
+      swr-refresh-after-seconds: ${APP_CACHE_L1_SWR_REFRESH_AFTER_SECONDS:15}
     l2:
       default-ttl-seconds: ${APP_CACHE_L2_DEFAULT_TTL_SECONDS:300}
       min-ttl-seconds: ${APP_CACHE_L2_MIN_TTL_SECONDS:5}
@@ -70,6 +73,10 @@ app:
       compression-enabled: ${APP_CACHE_CODEC_COMPRESSION_ENABLED:true}
       compression-threshold-bytes: ${APP_CACHE_CODEC_COMPRESSION_THRESHOLD_BYTES:1024}
       format: ${APP_CACHE_CODEC_FORMAT:msgpack}
+    invalidation:
+      enabled: ${APP_CACHE_INVALIDATION_ENABLED:true}
+      channel: ${APP_CACHE_INVALIDATION_CHANNEL:withbuddy:cache:invalidate}
+      node-id: ${APP_CACHE_INVALIDATION_NODE_ID:}
   security:
     cors:
       allowed-origin-patterns: ${CORS_ALLOWED_ORIGIN_PATTERNS:http://localhost:5173,https://*.vercel.app,https://withbuddy.itsdev.kr}


### PR DESCRIPTION
  2단계로 추가된 내용:                                                  
  - 변경 파일 목록 (7개 파일) + 각 변경 내용                          
  - L1 Read-through + Single-flight 흐름도 (resolveLocalValue 분기)
  - Negative Cache — miss 엔트리 저장 + negativeTtlSeconds 기반 만료 판정
  - SWR (Stale-While-Revalidate) — stale hit 즉시 반환 + 백그라운드 refresh, swrRefreshInFlight 중복 방지
  - L1 무효화 전파 (Redis Pub/Sub) — 발행/수신 흐름, nodeId 자기 발신 필터링
