### PR TITLE
Feature/scrum 361 423 unanswered metrics

### DIFF
--- a/backend/src/main/java/com/withbuddy/admin/metrics/controller/AdminMetricsController.java
+++ b/backend/src/main/java/com/withbuddy/admin/metrics/controller/AdminMetricsController.java
@@ -6,6 +6,7 @@ import com.withbuddy.admin.metrics.dto.response.RagExperienceRateResponse;
 import com.withbuddy.admin.metrics.dto.response.RevisitRateResponse;
 import com.withbuddy.admin.metrics.dto.response.TtaResponse;
 import com.withbuddy.admin.metrics.dto.response.UnansweredRateResponse;
+import com.withbuddy.admin.metrics.dto.response.UnansweredQuestionPatternsResponse;
 import com.withbuddy.admin.metrics.service.AdminMetricsService;
 import com.withbuddy.global.security.AuthenticationPrincipalResolver;
 import com.withbuddy.global.security.JwtAuthenticationPrincipal;
@@ -80,5 +81,17 @@ public class AdminMetricsController implements AdminMetricsControllerDocs {
     ) {
         JwtAuthenticationPrincipal principal = AuthenticationPrincipalResolver.requireJwtPrincipal(authentication);
         return ResponseEntity.ok(adminMetricsService.getTta(principal, companyCode, asOfDate));
+    }
+
+    @Override
+    @GetMapping("/unanswered-question-patterns")
+    public ResponseEntity<UnansweredQuestionPatternsResponse> getUnansweredQuestionPatterns(
+            Authentication authentication,
+            @RequestParam(required = false) String companyCode,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate asOfDate,
+            @RequestParam(required = false) Integer limit
+    ) {
+        JwtAuthenticationPrincipal principal = AuthenticationPrincipalResolver.requireJwtPrincipal(authentication);
+        return ResponseEntity.ok(adminMetricsService.getUnansweredQuestionPatterns(principal, companyCode, asOfDate, limit));
     }
 }

--- a/backend/src/main/java/com/withbuddy/admin/metrics/docs/AdminMetricsControllerDocs.java
+++ b/backend/src/main/java/com/withbuddy/admin/metrics/docs/AdminMetricsControllerDocs.java
@@ -5,6 +5,7 @@ import com.withbuddy.admin.metrics.dto.response.RagExperienceRateResponse;
 import com.withbuddy.admin.metrics.dto.response.RevisitRateResponse;
 import com.withbuddy.admin.metrics.dto.response.TtaResponse;
 import com.withbuddy.admin.metrics.dto.response.UnansweredRateResponse;
+import com.withbuddy.admin.metrics.dto.response.UnansweredQuestionPatternsResponse;
 import com.withbuddy.global.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -106,5 +107,23 @@ public interface AdminMetricsControllerDocs {
             @Parameter(hidden = true) Authentication authentication,
             @RequestParam(required = false) String companyCode,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate asOfDate
+    );
+
+    @Operation(summary = "미답변 질문 패턴 TOP N 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "패턴 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UnansweredQuestionPatternsResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<UnansweredQuestionPatternsResponse> getUnansweredQuestionPatterns(
+            @Parameter(hidden = true) Authentication authentication,
+            @RequestParam(required = false) String companyCode,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate asOfDate,
+            @RequestParam(required = false) Integer limit
     );
 }

--- a/backend/src/main/java/com/withbuddy/admin/metrics/dto/response/UnansweredQuestionPatternsResponse.java
+++ b/backend/src/main/java/com/withbuddy/admin/metrics/dto/response/UnansweredQuestionPatternsResponse.java
@@ -1,0 +1,23 @@
+package com.withbuddy.admin.metrics.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UnansweredQuestionPatternsResponse(
+        String metric,
+        LocalDate asOfDate,
+        int limit,
+        List<PatternItem> patterns
+) {
+    public record PatternItem(
+            String companyCode,
+            String questionContent,
+            long totalCount,
+            long uniqueUsers,
+            long noResultCount,
+            long outOfScopeCount,
+            LocalDateTime latestOccurredAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/withbuddy/admin/metrics/repository/AdminMetricsRepository.java
+++ b/backend/src/main/java/com/withbuddy/admin/metrics/repository/AdminMetricsRepository.java
@@ -2,10 +2,13 @@ package com.withbuddy.admin.metrics.repository;
 
 import com.withbuddy.account.user.entity.User;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @org.springframework.stereotype.Repository
@@ -208,6 +211,39 @@ public interface AdminMetricsRepository extends Repository<User, Long> {
             @Param("dayAfter") LocalDate dayAfter
     );
 
+    @Query(value = """
+            SELECT
+                log.company_code AS companyCode,
+                log.question_content AS questionContent,
+                COUNT(*) AS totalCount,
+                COUNT(DISTINCT log.user_id) AS uniqueUsers,
+                COUNT(CASE WHEN log.answer_type = 'no_result' THEN 1 END) AS noResultCount,
+                COUNT(CASE WHEN log.answer_type = 'out_of_scope' THEN 1 END) AS outOfScopeCount,
+                MAX(log.created_at) AS latestOccurredAt
+            FROM unanswered_question_logs log
+            WHERE log.created_at < :dayAfter
+              AND log.answer_type IN ('no_result', 'out_of_scope')
+              AND (:companyCode IS NULL OR log.company_code = :companyCode)
+            GROUP BY log.company_code, log.question_content
+            ORDER BY totalCount DESC, uniqueUsers DESC, latestOccurredAt DESC, questionContent
+            """,
+            countQuery = """
+            SELECT COUNT(*) FROM (
+                SELECT 1
+                FROM unanswered_question_logs log
+                WHERE log.created_at < :dayAfter
+                  AND log.answer_type IN ('no_result', 'out_of_scope')
+                  AND (:companyCode IS NULL OR log.company_code = :companyCode)
+                GROUP BY log.company_code, log.question_content
+            ) grouped_patterns
+            """,
+            nativeQuery = true)
+    Page<UnansweredQuestionPatternProjection> findUnansweredQuestionPatterns(
+            @Param("companyCode") String companyCode,
+            @Param("dayAfter") LocalDate dayAfter,
+            Pageable pageable
+    );
+
     interface RagExperienceMetricProjection {
         String getCompanyCode();
         String getCompanyName();
@@ -244,5 +280,15 @@ public interface AdminMetricsRepository extends Repository<User, Long> {
         Long getLoggedInUsers();
         Long getMeasuredUsers();
         Double getAverageTtaMinutes();
+    }
+
+    interface UnansweredQuestionPatternProjection {
+        String getCompanyCode();
+        String getQuestionContent();
+        Long getTotalCount();
+        Long getUniqueUsers();
+        Long getNoResultCount();
+        Long getOutOfScopeCount();
+        LocalDateTime getLatestOccurredAt();
     }
 }

--- a/backend/src/main/java/com/withbuddy/admin/metrics/service/AdminMetricsService.java
+++ b/backend/src/main/java/com/withbuddy/admin/metrics/service/AdminMetricsService.java
@@ -5,6 +5,7 @@ import com.withbuddy.admin.metrics.dto.response.RagExperienceRateResponse;
 import com.withbuddy.admin.metrics.dto.response.RevisitRateResponse;
 import com.withbuddy.admin.metrics.dto.response.TtaResponse;
 import com.withbuddy.admin.metrics.dto.response.UnansweredRateResponse;
+import com.withbuddy.admin.metrics.dto.response.UnansweredQuestionPatternsResponse;
 import com.withbuddy.admin.metrics.repository.AdminMetricsRepository;
 import com.withbuddy.account.auth.repository.UserRepository;
 import com.withbuddy.global.exception.ForbiddenException;
@@ -12,6 +13,7 @@ import com.withbuddy.global.exception.UnauthorizedException;
 import com.withbuddy.global.security.JwtAuthenticationPrincipal;
 import com.withbuddy.account.user.entity.User;
 import com.withbuddy.account.user.entity.UserRole;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,8 @@ import java.util.List;
 public class AdminMetricsService {
 
     private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final int DEFAULT_PATTERN_LIMIT = 5;
+    private static final int MAX_PATTERN_LIMIT = 20;
 
     private final AdminMetricsRepository adminMetricsRepository;
     private final UserRepository userRepository;
@@ -155,6 +159,42 @@ public class AdminMetricsService {
         return new TtaResponse("tta", resolvedAsOfDate, "minutes", companies);
     }
 
+    public UnansweredQuestionPatternsResponse getUnansweredQuestionPatterns(
+            JwtAuthenticationPrincipal principal,
+            String companyCode,
+            LocalDate asOfDate,
+            Integer limit
+    ) {
+        requireServiceAdmin(principal);
+        LocalDate resolvedAsOfDate = resolveAsOfDate(asOfDate);
+        LocalDate dayAfter = resolvedAsOfDate.plusDays(1);
+        int resolvedLimit = resolvePatternLimit(limit);
+
+        List<UnansweredQuestionPatternsResponse.PatternItem> patterns =
+                adminMetricsRepository.findUnansweredQuestionPatterns(
+                                companyCode,
+                                dayAfter,
+                                PageRequest.of(0, resolvedLimit)
+                        ).stream()
+                        .map(pattern -> new UnansweredQuestionPatternsResponse.PatternItem(
+                                pattern.getCompanyCode(),
+                                pattern.getQuestionContent(),
+                                defaultLong(pattern.getTotalCount()),
+                                defaultLong(pattern.getUniqueUsers()),
+                                defaultLong(pattern.getNoResultCount()),
+                                defaultLong(pattern.getOutOfScopeCount()),
+                                pattern.getLatestOccurredAt()
+                        ))
+                        .toList();
+
+        return new UnansweredQuestionPatternsResponse(
+                "unanswered_question_patterns",
+                resolvedAsOfDate,
+                resolvedLimit,
+                patterns
+        );
+    }
+
     private void requireServiceAdmin(JwtAuthenticationPrincipal principal) {
         User currentUser = userRepository.findById(principal.userId())
                 .orElseThrow(() -> new UnauthorizedException("인증된 사용자를 찾을 수 없습니다."));
@@ -183,5 +223,15 @@ public class AdminMetricsService {
 
         double ratio = defaultLong(numerator) * 100.0 / resolvedDenominator;
         return Math.round(ratio * 10.0) / 10.0;
+    }
+
+    private int resolvePatternLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_PATTERN_LIMIT;
+        }
+        if (limit < 1) {
+            return 1;
+        }
+        return Math.min(limit, MAX_PATTERN_LIMIT);
     }
 }

--- a/backend/src/main/java/com/withbuddy/buddy/chat/entity/ChatMessage.java
+++ b/backend/src/main/java/com/withbuddy/buddy/chat/entity/ChatMessage.java
@@ -49,6 +49,9 @@ public class ChatMessage {
     @Column(name = "answer_to_message_id")
     private Long answerToMessageId;
 
+    @Column(name = "latency_ms")
+    private Long latencyMs;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -61,7 +64,7 @@ public class ChatMessage {
             String content,
             String recommendedContactsJson
     ) {
-        this(userId, suggestionId, senderType, messageType, content, recommendedContactsJson, null);
+        this(userId, suggestionId, senderType, messageType, content, recommendedContactsJson, null, null);
     }
 
     @Builder
@@ -72,7 +75,8 @@ public class ChatMessage {
             MessageType messageType,
             String content,
             String recommendedContactsJson,
-            Long answerToMessageId
+            Long answerToMessageId,
+            Long latencyMs
     ) {
         this.userId = userId;
         this.suggestionId = suggestionId;
@@ -81,6 +85,7 @@ public class ChatMessage {
         this.content = content;
         this.recommendedContactsJson = recommendedContactsJson;
         this.answerToMessageId = answerToMessageId;
+        this.latencyMs = latencyMs;
     }
 
     public static ChatMessage createSuggestionMessage(Long userId, Long suggestionId, String content) {
@@ -92,6 +97,7 @@ public class ChatMessage {
         message.content = content;
         message.recommendedContactsJson = null;
         message.answerToMessageId = null;
+        message.latencyMs = null;
         return message;
     }
 }

--- a/backend/src/main/java/com/withbuddy/buddy/chat/entity/UnansweredQuestionLog.java
+++ b/backend/src/main/java/com/withbuddy/buddy/chat/entity/UnansweredQuestionLog.java
@@ -1,0 +1,73 @@
+package com.withbuddy.buddy.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "unanswered_question_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnansweredQuestionLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "company_code", nullable = false, length = 20)
+    private String companyCode;
+
+    @Column(name = "question_message_id", nullable = false)
+    private Long questionMessageId;
+
+    @Column(name = "answer_message_id", nullable = false)
+    private Long answerMessageId;
+
+    @Column(name = "question_content", nullable = false, columnDefinition = "TEXT")
+    private String questionContent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "answer_type", nullable = false, length = 30)
+    private MessageType answerType;
+
+    @Column(name = "latency_ms")
+    private Long latencyMs;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UnansweredQuestionLog(
+            Long userId,
+            String companyCode,
+            Long questionMessageId,
+            Long answerMessageId,
+            String questionContent,
+            MessageType answerType,
+            Long latencyMs
+    ) {
+        this.userId = userId;
+        this.companyCode = companyCode;
+        this.questionMessageId = questionMessageId;
+        this.answerMessageId = answerMessageId;
+        this.questionContent = questionContent;
+        this.answerType = answerType;
+        this.latencyMs = latencyMs;
+    }
+}

--- a/backend/src/main/java/com/withbuddy/buddy/chat/repository/UnansweredQuestionLogRepository.java
+++ b/backend/src/main/java/com/withbuddy/buddy/chat/repository/UnansweredQuestionLogRepository.java
@@ -1,0 +1,9 @@
+package com.withbuddy.buddy.chat.repository;
+
+import com.withbuddy.buddy.chat.entity.UnansweredQuestionLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UnansweredQuestionLogRepository extends JpaRepository<UnansweredQuestionLog, Long> {
+}

--- a/backend/src/main/java/com/withbuddy/buddy/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/withbuddy/buddy/chat/service/ChatMessageService.java
@@ -18,8 +18,10 @@ import com.withbuddy.buddy.chat.entity.ChatMessage;
 import com.withbuddy.buddy.chat.entity.ChatMessageDocument;
 import com.withbuddy.buddy.chat.entity.MessageType;
 import com.withbuddy.buddy.chat.entity.SenderType;
+import com.withbuddy.buddy.chat.entity.UnansweredQuestionLog;
 import com.withbuddy.buddy.chat.repository.ChatMessageDocumentRepository;
 import com.withbuddy.buddy.chat.repository.ChatMessageRepository;
+import com.withbuddy.buddy.chat.repository.UnansweredQuestionLogRepository;
 import com.withbuddy.global.exception.ForbiddenException;
 import com.withbuddy.global.exception.UnauthorizedException;
 import com.withbuddy.global.security.JwtAuthenticationPrincipal;
@@ -78,6 +80,7 @@ public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final ChatMessageDocumentRepository chatMessageDocumentRepository;
+    private final UnansweredQuestionLogRepository unansweredQuestionLogRepository;
     private final DocumentRepository documentRepository;
     private final DocumentFileRepository documentFileRepository;
     private final AiStreamClient aiStreamClient;
@@ -126,6 +129,7 @@ public class ChatMessageService {
                 );
                 sendStreamEvent(emitter, "question_saved", new ChatStreamQuestionSavedResponse(questionResponse));
 
+                long aiStartedAt = System.currentTimeMillis();
                 AiAnswerServerResponse aiResponse = aiStreamClient.streamAnswer(
                         questionId,
                         loginUserId,
@@ -135,6 +139,7 @@ public class ChatMessageService {
                         savedQuestionMessage.getContent(),
                         delta -> forwardDelta(emitter, delta)
                 );
+                long latencyMs = Math.max(0L, System.currentTimeMillis() - aiStartedAt);
 
                 MessageType answerMessageType = aiResponse.getMessageType();
                 List<Long> answerDocumentIds = filterExistingDocumentIds(extractDocumentIds(aiResponse));
@@ -146,11 +151,15 @@ public class ChatMessageService {
                 ChatMessage savedAnswerMessage = transactionTemplate.execute(
                         status -> saveAnswerMessage(
                                 loginUserId,
+                                companyCode,
+                                savedQuestionMessage.getContent(),
+                                savedQuestionId,
                                 resolveAnswerToMessageId(answerMessageType, savedQuestionId),
                                 answerMessageType,
                                 aiResponse.getContent(),
                                 answerDocumentIds,
-                                recommendedContactsJson
+                                recommendedContactsJson,
+                                latencyMs
                         )
                 );
                 if (savedAnswerMessage == null) {
@@ -261,11 +270,15 @@ public class ChatMessageService {
 
     private ChatMessage saveAnswerMessage(
             Long userId,
+            String companyCode,
+            String questionContent,
+            Long questionMessageId,
             Long answerToMessageId,
             MessageType answerMessageType,
             String answerContent,
             List<Long> answerDocumentIds,
-            String recommendedContactsJson
+            String recommendedContactsJson,
+            Long latencyMs
     ) {
         ChatMessage answerMessage = new ChatMessage(
                 userId,
@@ -274,11 +287,51 @@ public class ChatMessageService {
                 answerMessageType,
                 answerContent,
                 recommendedContactsJson,
-                answerToMessageId
+                answerToMessageId,
+                latencyMs
         );
         ChatMessage savedAnswerMessage = chatMessageRepository.save(answerMessage);
         saveDocumentMappings(savedAnswerMessage.getId(), answerDocumentIds);
+        saveUnansweredQuestionLog(
+                userId,
+                companyCode,
+                questionContent,
+                questionMessageId,
+                savedAnswerMessage,
+                latencyMs
+        );
         return savedAnswerMessage;
+    }
+
+    boolean shouldCreateUnansweredQuestionLog(MessageType answerMessageType) {
+        return answerMessageType == MessageType.no_result
+                || answerMessageType == MessageType.out_of_scope
+                || answerMessageType == MessageType.sensitive;
+    }
+
+    private void saveUnansweredQuestionLog(
+            Long userId,
+            String companyCode,
+            String questionContent,
+            Long questionMessageId,
+            ChatMessage savedAnswerMessage,
+            Long latencyMs
+    ) {
+        if (!shouldCreateUnansweredQuestionLog(savedAnswerMessage.getMessageType())) {
+            return;
+        }
+
+        unansweredQuestionLogRepository.save(
+                UnansweredQuestionLog.builder()
+                        .userId(userId)
+                        .companyCode(companyCode)
+                        .questionMessageId(questionMessageId)
+                        .answerMessageId(savedAnswerMessage.getId())
+                        .questionContent(questionContent)
+                        .answerType(savedAnswerMessage.getMessageType())
+                        .latencyMs(latencyMs)
+                        .build()
+        );
     }
 
     Long resolveAnswerToMessageId(MessageType answerMessageType, Long savedQuestionId) {

--- a/backend/src/main/resources/db/migration/V27__create_unanswered_question_logs.sql
+++ b/backend/src/main/resources/db/migration/V27__create_unanswered_question_logs.sql
@@ -1,0 +1,26 @@
+CREATE TABLE unanswered_question_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    company_code VARCHAR(20) NOT NULL,
+    question_message_id BIGINT NOT NULL,
+    answer_message_id BIGINT NOT NULL,
+    question_content TEXT NOT NULL,
+    answer_type VARCHAR(30) NOT NULL,
+    latency_ms BIGINT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_unanswered_question_logs PRIMARY KEY (id),
+    CONSTRAINT uq_unanswered_question_logs_answer_message UNIQUE (answer_message_id),
+    CONSTRAINT fk_unanswered_question_logs_user
+        FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_unanswered_question_logs_question_message
+        FOREIGN KEY (question_message_id) REFERENCES chat_messages (id),
+    CONSTRAINT fk_unanswered_question_logs_answer_message
+        FOREIGN KEY (answer_message_id) REFERENCES chat_messages (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+CREATE INDEX idx_unanswered_question_logs_company_created
+    ON unanswered_question_logs (company_code, created_at);
+
+CREATE INDEX idx_unanswered_question_logs_answer_type_created
+    ON unanswered_question_logs (answer_type, created_at);

--- a/backend/src/test/java/com/withbuddy/admin/metrics/service/AdminMetricsServiceTest.java
+++ b/backend/src/test/java/com/withbuddy/admin/metrics/service/AdminMetricsServiceTest.java
@@ -1,0 +1,173 @@
+package com.withbuddy.admin.metrics.service;
+
+import com.withbuddy.account.auth.repository.UserRepository;
+import com.withbuddy.account.user.entity.User;
+import com.withbuddy.admin.metrics.dto.response.UnansweredQuestionPatternsResponse;
+import com.withbuddy.admin.metrics.repository.AdminMetricsRepository;
+import com.withbuddy.global.security.JwtAuthenticationPrincipal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminMetricsServiceTest {
+
+    @Mock
+    private AdminMetricsRepository adminMetricsRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminMetricsService adminMetricsService;
+
+    @Test
+    void returnsTopPatternsWithDefaultLimit() {
+        JwtAuthenticationPrincipal principal = new JwtAuthenticationPrincipal(
+                1L,
+                "A001",
+                "관리자",
+                "WB0001",
+                "WithBuddy",
+                "2026-06-01"
+        );
+        User serviceAdmin = serviceAdmin();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(serviceAdmin));
+        when(adminMetricsRepository.findUnansweredQuestionPatterns(
+                org.mockito.ArgumentMatchers.eq("WB0001"),
+                org.mockito.ArgumentMatchers.eq(LocalDate.of(2026, 6, 2)),
+                org.mockito.ArgumentMatchers.any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of(pattern(
+                "WB0001",
+                "복지카드는 어떻게 신청하나요?",
+                4L,
+                3L,
+                3L,
+                1L,
+                LocalDateTime.of(2026, 6, 1, 13, 0)
+        ))));
+
+        UnansweredQuestionPatternsResponse response = adminMetricsService.getUnansweredQuestionPatterns(
+                principal,
+                "WB0001",
+                LocalDate.of(2026, 6, 1),
+                null
+        );
+
+        assertThat(response.metric()).isEqualTo("unanswered_question_patterns");
+        assertThat(response.limit()).isEqualTo(5);
+        assertThat(response.patterns()).hasSize(1);
+        assertThat(response.patterns().getFirst().questionContent()).isEqualTo("복지카드는 어떻게 신청하나요?");
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(adminMetricsRepository).findUnansweredQuestionPatterns(
+                org.mockito.ArgumentMatchers.eq("WB0001"),
+                org.mockito.ArgumentMatchers.eq(LocalDate.of(2026, 6, 2)),
+                pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(5);
+    }
+
+    @Test
+    void capsPatternLimitAtTwenty() {
+        JwtAuthenticationPrincipal principal = new JwtAuthenticationPrincipal(
+                1L,
+                "A001",
+                "관리자",
+                "WB0001",
+                "WithBuddy",
+                "2026-06-01"
+        );
+        User serviceAdmin = serviceAdmin();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(serviceAdmin));
+        when(adminMetricsRepository.findUnansweredQuestionPatterns(
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.eq(LocalDate.of(2026, 6, 2)),
+                org.mockito.ArgumentMatchers.any(Pageable.class)
+        )).thenReturn(new PageImpl<>(List.of()));
+
+        UnansweredQuestionPatternsResponse response = adminMetricsService.getUnansweredQuestionPatterns(
+                principal,
+                null,
+                LocalDate.of(2026, 6, 1),
+                100
+        );
+
+        assertThat(response.limit()).isEqualTo(20);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(adminMetricsRepository).findUnansweredQuestionPatterns(
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.eq(LocalDate.of(2026, 6, 2)),
+                pageableCaptor.capture()
+        );
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(20);
+    }
+
+    private User serviceAdmin() {
+        User user = org.mockito.Mockito.mock(User.class);
+        when(user.getRole()).thenReturn(com.withbuddy.account.user.entity.UserRole.SERVICE_ADMIN);
+        return user;
+    }
+
+    private AdminMetricsRepository.UnansweredQuestionPatternProjection pattern(
+            String companyCode,
+            String questionContent,
+            Long totalCount,
+            Long uniqueUsers,
+            Long noResultCount,
+            Long outOfScopeCount,
+            LocalDateTime latestOccurredAt
+    ) {
+        return new AdminMetricsRepository.UnansweredQuestionPatternProjection() {
+            @Override
+            public String getCompanyCode() {
+                return companyCode;
+            }
+
+            @Override
+            public String getQuestionContent() {
+                return questionContent;
+            }
+
+            @Override
+            public Long getTotalCount() {
+                return totalCount;
+            }
+
+            @Override
+            public Long getUniqueUsers() {
+                return uniqueUsers;
+            }
+
+            @Override
+            public Long getNoResultCount() {
+                return noResultCount;
+            }
+
+            @Override
+            public Long getOutOfScopeCount() {
+                return outOfScopeCount;
+            }
+
+            @Override
+            public LocalDateTime getLatestOccurredAt() {
+                return latestOccurredAt;
+            }
+        };
+    }
+}

--- a/backend/src/test/java/com/withbuddy/buddy/chat/service/ChatMessageServiceTest.java
+++ b/backend/src/test/java/com/withbuddy/buddy/chat/service/ChatMessageServiceTest.java
@@ -5,7 +5,9 @@ import com.withbuddy.buddy.chat.entity.ChatMessage;
 import com.withbuddy.buddy.chat.entity.MessageType;
 import com.withbuddy.buddy.chat.repository.ChatMessageDocumentRepository;
 import com.withbuddy.buddy.chat.repository.ChatMessageRepository;
+import com.withbuddy.buddy.chat.repository.UnansweredQuestionLogRepository;
 import com.withbuddy.buddy.onboarding.repository.OnboardingSuggestionRepository;
+import com.withbuddy.account.auth.repository.UserRepository;
 import com.withbuddy.infrastructure.ai.client.AiStreamClient;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
 import com.withbuddy.storage.repository.DocumentFileRepository;
@@ -34,6 +36,8 @@ class ChatMessageServiceTest {
     @Mock
     private ChatMessageDocumentRepository chatMessageDocumentRepository;
     @Mock
+    private UnansweredQuestionLogRepository unansweredQuestionLogRepository;
+    @Mock
     private DocumentRepository documentRepository;
     @Mock
     private DocumentFileRepository documentFileRepository;
@@ -51,6 +55,8 @@ class ChatMessageServiceTest {
     private QuickQuestionCatalog quickQuestionCatalog;
     @Mock
     private OnboardingSuggestionRepository onboardingSuggestionRepository;
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private ChatMessageService chatMessageService;
@@ -105,5 +111,33 @@ class ChatMessageServiceTest {
         Long result = chatMessageService.resolveAnswerToMessageId(MessageType.rag_answer, 201L);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    void createsUnansweredQuestionLogForNoResult() {
+        boolean result = chatMessageService.shouldCreateUnansweredQuestionLog(MessageType.no_result);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void createsUnansweredQuestionLogForOutOfScope() {
+        boolean result = chatMessageService.shouldCreateUnansweredQuestionLog(MessageType.out_of_scope);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void createsUnansweredQuestionLogForSensitive() {
+        boolean result = chatMessageService.shouldCreateUnansweredQuestionLog(MessageType.sensitive);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void doesNotCreateUnansweredQuestionLogForRagAnswer() {
+        boolean result = chatMessageService.shouldCreateUnansweredQuestionLog(MessageType.rag_answer);
+
+        assertThat(result).isFalse();
     }
 }


### PR DESCRIPTION



- SCRUM-361에서는 미답변 로그를 DB에 저장할 수 있는 기반을 추가
- SCRUM-423에서는 관리자용 미답변 질문 패턴 집계 API를 추가

2개 커밋
- fb3707b feat(be): add unanswered question logging
- a8f801b feat(be): add unanswered question pattern metrics api