### PR TITLE
SCRUM-540 accessToken이 localStorage에 평문 저장되는 보안 취약점

### DIFF
--- a/backend/src/main/java/com/withbuddy/account/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/controller/AuthController.java
@@ -1,15 +1,19 @@
 package com.withbuddy.account.auth.controller;
 
+import com.withbuddy.account.auth.cookie.AuthCookieService;
 import com.withbuddy.account.auth.docs.AuthControllerDocs;
 import com.withbuddy.account.auth.dto.request.LoginRequest;
 import com.withbuddy.account.auth.dto.response.LoginResponse;
+import com.withbuddy.account.auth.dto.response.LoginUserResponse;
 import com.withbuddy.account.auth.service.AuthService;
 import com.withbuddy.global.security.AuthenticationPrincipalResolver;
 import com.withbuddy.global.security.JwtAuthenticationPrincipal;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,23 +24,37 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthControllerDocs {
 
     private final AuthService authService;
+    private final AuthCookieService authCookieService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, AuthCookieService authCookieService) {
         this.authService = authService;
+        this.authCookieService = authCookieService;
     }
 
     @Override
     @PostMapping("/login")
-    public LoginResponse login(@Valid @RequestBody LoginRequest loginRequest, HttpServletRequest request) {
-        return authService.login(loginRequest, resolveClientIp(request));
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest, HttpServletRequest request) {
+        AuthService.AuthenticatedSession session = authService.login(loginRequest, resolveClientIp(request));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, authCookieService.createAccessTokenCookie(request, session.accessToken()).toString())
+                .body(new LoginResponse(session.user()));
+    }
+
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<LoginUserResponse> me(Authentication authentication) {
+        JwtAuthenticationPrincipal principal = AuthenticationPrincipalResolver.requireJwtPrincipal(authentication);
+        return ResponseEntity.ok(authService.getCurrentUser(principal.userId()));
     }
 
     @Override
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(Authentication authentication) {
+    public ResponseEntity<Void> logout(Authentication authentication, HttpServletRequest request) {
         JwtAuthenticationPrincipal principal = AuthenticationPrincipalResolver.requireJwtPrincipal(authentication);
         authService.logout(principal.userId());
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, authCookieService.expireAccessTokenCookie(request).toString())
+                .build();
     }
 
     private String resolveClientIp(HttpServletRequest request) {

--- a/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieNames.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieNames.java
@@ -1,0 +1,9 @@
+package com.withbuddy.account.auth.cookie;
+
+public final class AuthCookieNames {
+
+    public static final String ACCESS_TOKEN = "WB_ACCESS_TOKEN";
+
+    private AuthCookieNames() {
+    }
+}

--- a/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieProperties.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieProperties.java
@@ -1,0 +1,19 @@
+package com.withbuddy.account.auth.cookie;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.security.auth-cookie")
+public class AuthCookieProperties {
+
+    private String sameSite = "Lax";
+    private String domain;
+    private String path = "/";
+    private boolean httpOnly = true;
+    private Boolean secure;
+}

--- a/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieService.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieService.java
@@ -1,0 +1,85 @@
+package com.withbuddy.account.auth.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class AuthCookieService {
+
+    private final AuthCookieProperties authCookieProperties;
+    private final long accessExpirationMillis;
+
+    public AuthCookieService(
+            AuthCookieProperties authCookieProperties,
+            @Value("${jwt.access-expiration}") long accessExpirationMillis
+    ) {
+        this.authCookieProperties = authCookieProperties;
+        this.accessExpirationMillis = accessExpirationMillis;
+    }
+
+    public ResponseCookie createAccessTokenCookie(HttpServletRequest request, String token) {
+        return baseCookieBuilder(request)
+                .value(token)
+                .maxAge(Duration.ofMillis(accessExpirationMillis))
+                .build();
+    }
+
+    public ResponseCookie expireAccessTokenCookie(HttpServletRequest request) {
+        return baseCookieBuilder(request)
+                .value("")
+                .maxAge(Duration.ZERO)
+                .build();
+    }
+
+    public Optional<String> resolveAccessToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> AuthCookieNames.ACCESS_TOKEN.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .filter(StringUtils::hasText)
+                .findFirst();
+    }
+
+    private ResponseCookie.ResponseCookieBuilder baseCookieBuilder(HttpServletRequest request) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(
+                AuthCookieNames.ACCESS_TOKEN,
+                ""
+        );
+
+        builder.httpOnly(authCookieProperties.isHttpOnly());
+        builder.secure(resolveSecure(request));
+        builder.sameSite(authCookieProperties.getSameSite());
+        builder.path(authCookieProperties.getPath());
+
+        if (StringUtils.hasText(authCookieProperties.getDomain())) {
+            builder.domain(authCookieProperties.getDomain().trim());
+        }
+
+        return builder;
+    }
+
+    private boolean resolveSecure(HttpServletRequest request) {
+        if (authCookieProperties.getSecure() != null) {
+            return authCookieProperties.getSecure();
+        }
+
+        if (request.isSecure()) {
+            return true;
+        }
+
+        String forwardedProto = request.getHeader("X-Forwarded-Proto");
+        return "https".equalsIgnoreCase(forwardedProto);
+    }
+}

--- a/backend/src/main/java/com/withbuddy/account/auth/docs/AuthControllerDocs.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/docs/AuthControllerDocs.java
@@ -2,6 +2,7 @@ package com.withbuddy.account.auth.docs;
 
 import com.withbuddy.account.auth.dto.request.LoginRequest;
 import com.withbuddy.account.auth.dto.response.LoginResponse;
+import com.withbuddy.account.auth.dto.response.LoginUserResponse;
 import com.withbuddy.global.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,14 +21,14 @@ public interface AuthControllerDocs {
     @Operation(
         summary = "로그인",
         description = """
-            [목적] 회사코드·사번·이름으로 사용자를 인증하고 accessToken을 발급한다.
+            [목적] 회사코드·사번·이름으로 사용자를 인증하고 httpOnly 세션 쿠키를 발급한다.
             [추가 보안] Turnstile 보호가 활성화된 환경에서는 turnstileToken도 함께 검증한다.
-            [베네핏] 발급된 accessToken을 Redis에 저장해 단일 기기 세션을 강제한다. \
+            [베네핏] 발급된 세션 토큰을 Redis에 저장해 단일 기기 세션을 강제한다. \
             다른 기기에서 재로그인 시 이전 세션이 자동 무효화되어 계정 보안을 강화한다. \
-            이후 모든 API 호출에 이 토큰을 사용한다."""
+            이후 모든 API 호출은 브라우저가 자동 전송하는 쿠키를 사용한다."""
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "로그인 성공 — accessToken 반환",
+        @ApiResponse(responseCode = "200", description = "로그인 성공 — 세션 쿠키 발급 및 사용자 정보 반환",
                 content = @Content(schema = @Schema(implementation = LoginResponse.class))),
         @ApiResponse(responseCode = "400", description = "보안 검증 실패 — Turnstile 토큰 누락 또는 검증 실패",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -38,12 +39,26 @@ public interface AuthControllerDocs {
         @ApiResponse(responseCode = "401", description = "로그인 실패 — 회사코드·사번·이름 불일치",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    LoginResponse login(LoginRequest loginRequest, @Parameter(hidden = true) HttpServletRequest request);
+    ResponseEntity<LoginResponse> login(LoginRequest loginRequest, @Parameter(hidden = true) HttpServletRequest request);
+
+    @Operation(
+        summary = "현재 사용자 조회",
+        description = """
+            [목적] 현재 세션 쿠키를 기준으로 로그인된 사용자 정보를 조회한다.
+            [베네핏] 프론트엔드가 새로고침 이후에도 서버 기준 세션 상태를 복원할 수 있다."""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공 — 현재 로그인 사용자 정보 반환",
+                content = @Content(schema = @Schema(implementation = LoginUserResponse.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패 — 세션 쿠키 없음 또는 만료",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<LoginUserResponse> me(@Parameter(hidden = true) Authentication authentication);
 
     @Operation(
         summary = "로그아웃",
         description = """
-            [목적] 현재 로그인 세션을 종료하고 Redis에서 토큰을 즉시 삭제한다.
+            [목적] 현재 로그인 세션을 종료하고 Redis에서 토큰을 즉시 삭제한 뒤 인증 쿠키를 만료시킨다.
             [베네핏] 로그아웃 즉시 해당 토큰이 무효화되어 탈취된 토큰으로의 API 접근을 차단한다. \
             공용 PC나 모바일 분실 상황에서 원격으로 세션을 종료할 수 있다."""
     )
@@ -52,5 +67,8 @@ public interface AuthControllerDocs {
         @ApiResponse(responseCode = "401", description = "인증 실패 — 이미 만료된 토큰",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> logout(@Parameter(hidden = true) Authentication authentication);
+    ResponseEntity<Void> logout(
+            @Parameter(hidden = true) Authentication authentication,
+            @Parameter(hidden = true) HttpServletRequest request
+    );
 }

--- a/backend/src/main/java/com/withbuddy/account/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/dto/response/LoginResponse.java
@@ -9,9 +9,6 @@ import lombok.Getter;
 @Schema(description = "로그인 성공 응답")
 public class LoginResponse {
 
-    @Schema(description = "액세스 토큰")
-    private String accessToken;
-
     @Schema(description = "로그인 사용자 정보")
     private LoginUserResponse user;
 }

--- a/backend/src/main/java/com/withbuddy/account/auth/service/AuthService.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/service/AuthService.java
@@ -8,12 +8,12 @@ import com.withbuddy.admin.activity.log.RmqActivityLogService;
 import com.withbuddy.admin.activity.entity.EventTarget;
 import com.withbuddy.admin.activity.entity.EventType;
 import com.withbuddy.account.auth.dto.request.LoginRequest;
-import com.withbuddy.account.auth.dto.response.LoginResponse;
 import com.withbuddy.account.auth.dto.response.LoginUserResponse;
 import com.withbuddy.account.auth.exception.LoginFailedException;
 import com.withbuddy.account.auth.ratelimit.LoginAttemptRateLimitService;
 import com.withbuddy.account.auth.turnstile.TurnstileVerificationService;
 import com.withbuddy.account.auth.repository.UserRepository;
+import com.withbuddy.global.exception.UnauthorizedException;
 import com.withbuddy.global.jwt.JwtService;
 import com.withbuddy.infrastructure.redis.RedisCacheKeys;
 import com.withbuddy.infrastructure.redis.RedisCacheService;
@@ -44,7 +44,7 @@ public class AuthService {
     private final LoginAttemptRateLimitService loginAttemptRateLimitService;
 
     @Transactional
-    public LoginResponse login(LoginRequest request, String clientIp) {
+    public AuthenticatedSession login(LoginRequest request, String clientIp) {
         String normalizedCompanyCode = normalizeCompanyCode(request.getCompanyCode());
         String normalizedEmployeeNumber = normalizeValue(request.getEmployeeNumber());
         String normalizedName = normalizeValue(request.getName());
@@ -91,21 +91,25 @@ public class AuthService {
             rmqActivityLogService.publish(user.getId(), EventType.SESSION_START, EventTarget.LOGIN);
         }
 
-        LoginUserResponse userResponse = new LoginUserResponse(
-                user.getId(),
-                user.getCompany().getCompanyCode(),
-                user.getCompany().getName(),
-                user.getEmployeeNumber(),
-                user.getName(),
-                user.getDepartment(),
-                user.getTeamName(),
-                user.getRole(),
-                resolveResponseAccountStatus(user, currentAccountStatus),
-                user.getHireDate()
-        );
+        LoginUserResponse userResponse = buildUserResponse(user, currentAccountStatus);
         cacheUserProfile(user.getId(), userResponse);
 
-        return new LoginResponse(accessToken, userResponse);
+        return new AuthenticatedSession(accessToken, userResponse);
+    }
+
+    @Transactional
+    public LoginUserResponse getCurrentUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UnauthorizedException("사용자 정보를 찾을 수 없습니다."));
+
+        UserAccountStatus currentAccountStatus = resolveLifecycleAccountStatus(user);
+        if (user.getRole() == UserRole.USER && user.getAccountStatus() != currentAccountStatus) {
+            user.updateAccountStatus(currentAccountStatus);
+        }
+
+        LoginUserResponse userResponse = buildUserResponse(user, currentAccountStatus);
+        cacheUserProfile(userId, userResponse);
+        return userResponse;
     }
 
     private UserAccountStatus resolveResponseAccountStatus(User user, UserAccountStatus currentAccountStatus) {
@@ -139,6 +143,21 @@ public class AuthService {
         }
     }
 
+    private LoginUserResponse buildUserResponse(User user, UserAccountStatus currentAccountStatus) {
+        return new LoginUserResponse(
+                user.getId(),
+                user.getCompany().getCompanyCode(),
+                user.getCompany().getName(),
+                user.getEmployeeNumber(),
+                user.getName(),
+                user.getDepartment(),
+                user.getTeamName(),
+                user.getRole(),
+                resolveResponseAccountStatus(user, currentAccountStatus),
+                user.getHireDate()
+        );
+    }
+
     private String normalizeCompanyCode(String value) {
         return normalizeValue(value).toUpperCase(Locale.ROOT);
     }
@@ -166,5 +185,8 @@ public class AuthService {
             return UserAccountStatus.READ_ONLY;
         }
         return UserAccountStatus.ACTIVE;
+    }
+
+    public record AuthenticatedSession(String accessToken, LoginUserResponse user) {
     }
 }

--- a/backend/src/main/java/com/withbuddy/global/config/SwaggerSecurityConfig.java
+++ b/backend/src/main/java/com/withbuddy/global/config/SwaggerSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.withbuddy.global.config;
 
+import com.withbuddy.account.auth.cookie.AuthCookieNames;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.PathItem;
@@ -13,11 +15,11 @@ import java.util.Set;
 
 @Configuration
 @SecurityScheme(
-        name = "bearerAuth",
-        type = SecuritySchemeType.HTTP,
-        scheme = "bearer",
-        bearerFormat = "JWT",
-        description = "로그인 후 발급된 accessToken을 입력하세요. 'Bearer ' 접두사 없이 토큰만 입력하면 됩니다."
+        name = "sessionCookieAuth",
+        type = SecuritySchemeType.APIKEY,
+        in = SecuritySchemeIn.COOKIE,
+        paramName = AuthCookieNames.ACCESS_TOKEN,
+        description = "로그인 후 브라우저에 저장되는 httpOnly 세션 쿠키를 사용합니다."
 )
 public class SwaggerSecurityConfig {
 
@@ -28,7 +30,7 @@ public class SwaggerSecurityConfig {
     @Bean
     public OpenApiCustomizer globalSecurityCustomizer() {
         return openApi -> {
-            openApi.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+            openApi.addSecurityItem(new SecurityRequirement().addList("sessionCookieAuth"));
 
             if (openApi.getPaths() == null) {
                 return;

--- a/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/withbuddy/global/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.withbuddy.global.security;
 
+import com.withbuddy.account.auth.cookie.AuthCookieService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.withbuddy.global.dto.ErrorResponse;
 import com.withbuddy.global.dto.FieldValidationError;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -44,10 +46,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final ObjectMapper objectMapper;
+    private final AuthCookieService authCookieService;
 
-    public JwtAuthenticationFilter(JwtService jwtService, ObjectMapper objectMapper) {
+    public JwtAuthenticationFilter(
+            JwtService jwtService,
+            ObjectMapper objectMapper,
+            AuthCookieService authCookieService
+    ) {
         this.jwtService = jwtService;
         this.objectMapper = objectMapper;
+        this.authCookieService = authCookieService;
     }
 
     @Override
@@ -61,14 +69,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
+        Optional<String> cookieToken = authCookieService.resolveAccessToken(request);
         String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
-        if (!StringUtils.hasText(authorizationHeader)) {
+        if (cookieToken.isEmpty() && !StringUtils.hasText(authorizationHeader)) {
             filterChain.doFilter(request, response);
             return;
         }
 
         try {
-            String token = jwtService.extractBearerToken(authorizationHeader);
+            String token = resolveToken(cookieToken, authorizationHeader);
             Claims claims = jwtService.getClaims(token);
 
             Long userId = Long.parseLong(claims.getSubject());
@@ -95,23 +104,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         } catch (TokenMissingException e) {
             String maskedPath = RequestUrlMaskingSupport.resolveMaskedPath(request);
+            clearCookieIfPresent(request, response, cookieToken);
             writeUnauthorized(response, maskedPath, "TOKEN_MISSING", "auth", e.getMessage());
             return;
         } catch (SessionExpiredException | ExpiredJwtException e) {
             String maskedPath = RequestUrlMaskingSupport.resolveMaskedPath(request);
+            clearCookieIfPresent(request, response, cookieToken);
             writeUnauthorized(response, maskedPath, "SESSION_EXPIRED", "session", e.getMessage());
             return;
         } catch (SessionRevokedException e) {
             String maskedPath = RequestUrlMaskingSupport.resolveMaskedPath(request);
+            clearCookieIfPresent(request, response, cookieToken);
             writeUnauthorized(response, maskedPath, "SESSION_REVOKED", "session", e.getMessage());
             return;
         } catch (UnauthorizedException | JwtException | IllegalArgumentException e) {
             String maskedPath = RequestUrlMaskingSupport.resolveMaskedPath(request);
+            clearCookieIfPresent(request, response, cookieToken);
             writeUnauthorized(response, maskedPath, "INVALID_TOKEN", "token", e.getMessage());
             return;
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(Optional<String> cookieToken, String authorizationHeader) {
+        if (cookieToken.isPresent()) {
+            return cookieToken.get();
+        }
+
+        if (!StringUtils.hasText(authorizationHeader)) {
+            return null;
+        }
+
+        return jwtService.extractBearerToken(authorizationHeader);
+    }
+
+    private void clearCookieIfPresent(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Optional<String> cookieToken
+    ) {
+        if (cookieToken.isEmpty()) {
+            return;
+        }
+        response.addHeader("Set-Cookie", authCookieService.expireAccessTokenCookie(request).toString());
     }
 
     private void writeUnauthorized(

--- a/backend/src/test/java/com/withbuddy/global/security/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/withbuddy/global/security/JwtAuthenticationFilterTest.java
@@ -1,5 +1,6 @@
 package com.withbuddy.global.security;
 
+import com.withbuddy.account.auth.cookie.AuthCookieService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.withbuddy.global.jwt.JwtService;
@@ -17,6 +18,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,17 +26,20 @@ class JwtAuthenticationFilterTest {
 
     @Mock
     private JwtService jwtService;
+    @Mock
+    private AuthCookieService authCookieService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void returns503WhenRedisConnectionFailsDuringAuthentication() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper, authCookieService);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
         request.addHeader("Authorization", "Bearer test-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
+        when(authCookieService.resolveAccessToken(request)).thenReturn(java.util.Optional.empty());
         when(jwtService.extractBearerToken("Bearer test-token")).thenReturn("test-token");
         when(jwtService.getClaims("test-token"))
                 .thenThrow(new RedisConnectionFailureException("redis connection failed"));
@@ -53,12 +58,13 @@ class JwtAuthenticationFilterTest {
 
     @Test
     void returns503WhenRedisQueryTimeoutOccursDuringAuthentication() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper, authCookieService);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
         request.addHeader("Authorization", "Bearer test-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
+        when(authCookieService.resolveAccessToken(request)).thenReturn(java.util.Optional.empty());
         when(jwtService.extractBearerToken("Bearer test-token")).thenReturn("test-token");
         when(jwtService.getClaims("test-token"))
                 .thenThrow(new QueryTimeoutException("redis query timeout"));
@@ -75,12 +81,13 @@ class JwtAuthenticationFilterTest {
 
     @Test
     void returns401SessionExpiredWhenRedisSessionIsMissingEvenIfJwtIsValid() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper, authCookieService);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
         request.addHeader("Authorization", "Bearer still-valid-jwt");
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
+        when(authCookieService.resolveAccessToken(request)).thenReturn(java.util.Optional.empty());
         when(jwtService.extractBearerToken("Bearer still-valid-jwt")).thenReturn("still-valid-jwt");
         when(jwtService.getClaims("still-valid-jwt"))
                 .thenThrow(new SessionExpiredException("redis session expired before jwt exp"));
@@ -98,12 +105,13 @@ class JwtAuthenticationFilterTest {
 
     @Test
     void returns401SessionRevokedOnDuplicateLogin() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper, authCookieService);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
         request.addHeader("Authorization", "Bearer previous-device-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
+        when(authCookieService.resolveAccessToken(request)).thenReturn(java.util.Optional.empty());
         when(jwtService.extractBearerToken("Bearer previous-device-token")).thenReturn("previous-device-token");
         when(jwtService.getClaims("previous-device-token"))
                 .thenThrow(new SessionRevokedException("token was revoked by another login"));
@@ -121,12 +129,13 @@ class JwtAuthenticationFilterTest {
 
     @Test
     void returns401TokenMissingWhenAuthorizationHeaderHasNoToken() throws Exception {
-        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper);
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper, authCookieService);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
         request.addHeader("Authorization", "Bearer   ");
         MockHttpServletResponse response = new MockHttpServletResponse();
         MockFilterChain chain = new MockFilterChain();
 
+        when(authCookieService.resolveAccessToken(request)).thenReturn(java.util.Optional.empty());
         when(jwtService.extractBearerToken("Bearer   "))
                 .thenThrow(new TokenMissingException("인증 토큰이 없습니다."));
 
@@ -139,5 +148,31 @@ class JwtAuthenticationFilterTest {
         assertThat(body.get("code").asText()).isEqualTo("TOKEN_MISSING");
         assertThat(body.get("status").asInt()).isEqualTo(401);
         assertThat(body.get("errors").get(0).get("field").asText()).isEqualTo("auth");
+    }
+
+    @Test
+    void authenticatesWithCookieTokenWhenAuthorizationHeaderIsMissing() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtService, objectMapper, authCookieService);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/chat/messages");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        io.jsonwebtoken.Claims claims = mock(io.jsonwebtoken.Claims.class);
+        when(claims.getSubject()).thenReturn("1");
+        when(claims.get("employeeNumber", String.class)).thenReturn("20260001");
+        when(claims.get("name", String.class)).thenReturn("홍길동");
+        when(claims.get("companyCode", String.class)).thenReturn("WB0001");
+        when(claims.get("companyName", String.class)).thenReturn("위드버디");
+        when(claims.get("hireDate", String.class)).thenReturn("2026-03-01");
+
+        when(authCookieService.resolveAccessToken(request)).thenReturn(java.util.Optional.of("cookie-token"));
+        when(jwtService.getClaims("cookie-token")).thenReturn(claims);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(chain.getRequest()).isNotNull();
+        assertThat(org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        org.springframework.security.core.context.SecurityContextHolder.clearContext();
     }
 }


### PR DESCRIPTION
변경 내용:

로그인 응답 DTO에서 accessToken 필드를 제거하고 사용자 정보만 반환하도록 수정: withbuddy/
backend/src/main/java/com/withbuddy/account/auth/dto/response/LoginResponse.java

로그인 시 쿠키 발급, 로그아웃 시 쿠키 만료, 현재 사용자 조회 GET /api/v1/auth/me 추가:
withbuddy/backend/src/main/java/com/withbuddy/account/auth/controller/AuthController.java

세션 쿠키 설정용 전용 컴포넌트 추가:

withbuddy/backend/src/main/java/com/withbuddy/account/auth/cookie/AuthCookieNames.java

withbuddy/backend/src/main/java/com/withbuddy/account/auth/cookie/
AuthCookieProperties.java

withbuddy/backend/src/main/java/com/withbuddy/account/auth/cookie/
AuthCookieService.java

AuthService에서 로그인 결과를 AuthenticatedSession으로 반환하고, 현재 사용자 정보 조회 로
직 추가: withbuddy/backend/src/main/java/com/withbuddy/account/auth/service/
AuthService.java

JWT 필터가 Authorization 헤더뿐 아니라 쿠키에서도 토큰을 읽도록 수정. 쿠키 인증 실패 시 만
료 쿠키도 내려주도록 처리: withbuddy/backend/src/main/java/com/withbuddy/global/security/
JwtAuthenticationFilter.java

Swagger/OpenAPI 설명을 bearer 토큰 입력 방식에서 cookie 인증 방식으로 수정: withbuddy/
backend/src/main/java/com/withbuddy/global/config/SwaggerSecurityConfig.java, withbuddy/
backend/src/main/java/com/withbuddy/account/auth/docs/AuthControllerDocs.java

JWT 필터 테스트에 쿠키 인증 케이스 추가 및 회귀 검증 반영: withbuddy/backend/src/test/
java/com/withbuddy/global/security/JwtAuthenticationFilterTest.java

검증 결과:

backend\gradlew.bat compileJava → 성공
backend\gradlew.bat test --tests com.withbuddy.global.security.JwtAuthenticationFilterTest
→ 성공
