### PR TITLE
SCRUM-540 resolve auth conflict markers

### DIFF
--- a/backend/src/main/java/com/withbuddy/account/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController implements AuthControllerDocs {
         AuthService.AuthenticatedSession session = authService.login(loginRequest, resolveClientIp(request));
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, authCookieService.createAccessTokenCookie(request, session.accessToken()).toString())
-                .body(new LoginResponse(session.user()));
+                .body(new LoginResponse(session.accessToken(), session.user()));
     }
 
     @Override

--- a/backend/src/main/java/com/withbuddy/account/auth/docs/AuthControllerDocs.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/docs/AuthControllerDocs.java
@@ -25,10 +25,10 @@ public interface AuthControllerDocs {
             [추가 보안] Turnstile 보호가 활성화된 환경에서는 turnstileToken도 함께 검증한다.
             [베네핏] 발급된 세션 토큰을 Redis에 저장해 단일 기기 세션을 강제한다. \
             다른 기기에서 재로그인 시 이전 세션이 자동 무효화되어 계정 보안을 강화한다. \
-            이후 모든 API 호출은 브라우저가 자동 전송하는 쿠키를 사용한다."""
+            기존 프론트 호환을 위해 accessToken도 응답 바디에 함께 유지한다."""
     )
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "로그인 성공 — 세션 쿠키 발급 및 사용자 정보 반환",
+        @ApiResponse(responseCode = "200", description = "로그인 성공 — 세션 쿠키 발급 및 accessToken/사용자 정보 반환",
                 content = @Content(schema = @Schema(implementation = LoginResponse.class))),
         @ApiResponse(responseCode = "400", description = "보안 검증 실패 — Turnstile 토큰 누락 또는 검증 실패",
                 content = @Content(schema = @Schema(implementation = ErrorResponse.class))),

--- a/backend/src/main/java/com/withbuddy/account/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/withbuddy/account/auth/dto/response/LoginResponse.java
@@ -9,6 +9,9 @@ import lombok.Getter;
 @Schema(description = "로그인 성공 응답")
 public class LoginResponse {
 
+    @Schema(description = "기존 프론트 하위 호환을 위한 accessToken")
+    private String accessToken;
+
     @Schema(description = "로그인 사용자 정보")
     private LoginUserResponse user;
 }


### PR DESCRIPTION
  - 로그인 응답은 쿠키를 내려주면서도
  - 기존 프론트 하위 호환을 위해 accessToken을 응답 바디에 유지